### PR TITLE
Fix panels migration to cover tables in core

### DIFF
--- a/db/deploy/add-panels-plugin.sql
+++ b/db/deploy/add-panels-plugin.sql
@@ -36,4 +36,31 @@ ALTER TABLE panel_application
 ALTER TABLE panel_applicant
         ADD CONSTRAINT panel_applicant_app_id_fkey FOREIGN KEY (app_id) REFERENCES panel_application(id) ON DELETE CASCADE;
 
+CREATE TABLE assigned_panelist (
+	id uuid NOT NULL,
+	attendee_id uuid NOT NULL,
+	event_id uuid NOT NULL
+);
+
+CREATE TABLE event (
+	id uuid NOT NULL,
+	location integer NOT NULL,
+	start_time timestamp without time zone NOT NULL,
+	duration integer NOT NULL,
+	name character varying DEFAULT ''::character varying NOT NULL,
+	description character varying DEFAULT ''::character varying NOT NULL
+);
+
+ALTER TABLE assigned_panelist
+	ADD CONSTRAINT assigned_panelist_pkey PRIMARY KEY (id);
+
+ALTER TABLE event
+	ADD CONSTRAINT event_pkey PRIMARY KEY (id);
+
+ALTER TABLE assigned_panelist
+	ADD CONSTRAINT assigned_panelist_attendee_id_fkey FOREIGN KEY (attendee_id) REFERENCES attendee(id) ON DELETE CASCADE;
+
+ALTER TABLE assigned_panelist
+	ADD CONSTRAINT assigned_panelist_event_id_fkey FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE;
+
 COMMIT;

--- a/db/revert/add-panels-plugin.sql
+++ b/db/revert/add-panels-plugin.sql
@@ -6,4 +6,8 @@ DROP TABLE panel_applicant;
 
 DROP TABLE panel_application;
 
+DROP TABLE assigned_panelist;
+
+DROP TABLE event;
+
 COMMIT;

--- a/db/verify/add-panels-plugin.sql
+++ b/db/verify/add-panels-plugin.sql
@@ -4,5 +4,7 @@ BEGIN;
 
 SELECT * from panel_applicant;
 SELECT * from panel_application;
+SELECT * from assigned_panelist;
+SELECT * from event;
 
 ROLLBACK;


### PR DESCRIPTION
I mistakenly created the migration without removing the tables that were already in core first; I've manually added those changes in.
