### PR TITLE
added ability to associate applications with events on the schedule

### DIFF
--- a/panels/automated_emails.py
+++ b/panels/automated_emails.py
@@ -16,3 +16,9 @@ PanelAppEmail('Your {EVENT_NAME} Panel Application Has Been Accepted', 'panel_ap
 
 PanelAppEmail('Your {EVENT_NAME} Panel Application Has Been Declined', 'panel_app_declined.txt',
               lambda app: app.status == c.DECLINED)
+
+PanelAppEmail('Your {EVENT_NAME} Panel Application Has Been Waitlisted', 'panel_app_waitlisted.txt',
+              lambda app: app.status == c.WAITLISTED)
+
+PanelAppEmail('Your {EVENT_NAME} Panel Has Been Scheduled', 'panel_app_scheduled.txt',
+              lambda app: app.event_id)

--- a/panels/config.py
+++ b/panels/config.py
@@ -11,6 +11,8 @@ c.ORDERED_EVENT_LOCS = [loc for loc, desc in c.EVENT_LOCATION_OPTS]
 c.EVENT_BOOKED = {'colspan': 0}
 c.EVENT_OPEN   = {'colspan': 1}
 
+c.PANEL_ROOMS = [getattr(c, room.upper()) for room in c.PANEL_ROOMS]
+
 # This can go away if/when we implement plugin enum merging
 c.ACCESS.update(c.PANEL_ACCESS_LEVELS)
 c.ACCESS_OPTS.extend(c.PANEL_ACCESS_LEVEL_OPTS)

--- a/panels/configspec.ini
+++ b/panels/configspec.ini
@@ -12,6 +12,10 @@ event_location = string
 # be ready, so we just set this to false whenever it is.
 hide_schedule = boolean(default=True)
 
+# These are the areas from which we'll show events to associated with panel
+# applications on the schedule.
+panel_rooms = string_list(default=list("panels_1", "panels_2", "panels_3", "panels_4"))
+
 
 [dates]
 panel_app_deadline = string
@@ -56,3 +60,4 @@ decline = string(default="Reject")
 pending = string(default="Pending")
 accepted = string(default="Accepted")
 declined = string(default="Declined")
+waitlisted = string(default="Waitlisted")

--- a/panels/models.py
+++ b/panels/models.py
@@ -25,6 +25,7 @@ class Event(MagModel):
     description = Column(UnicodeText)
 
     assigned_panelists = relationship('AssignedPanelist', backref='event')
+    application = relationship('PanelApplication', backref='event')
 
     @property
     def half_hours(self):
@@ -56,6 +57,8 @@ class AssignedPanelist(MagModel):
 
 
 class PanelApplication(MagModel):
+    event_id = Column(UUID, ForeignKey('event.id'), nullable=True)
+
     name = Column(UnicodeText)
     length = Column(UnicodeText)
     description = Column(UnicodeText)

--- a/panels/site_sections/panel_app_management.py
+++ b/panels/site_sections/panel_app_management.py
@@ -48,41 +48,64 @@ class Root:
         app.status = int(status)
         create_group = len(app.applicants) - len(app.matching_attendees) > 1 and not getattr(app.submitter.matching_attendee, 'group_id', None)
         if cherrypy.request.method == 'POST':
-            leader = None
-            group = Group(name='Panelists for ' + app.name, cost=0, auto_recalc=False) if create_group else None
-            for applicant in app.applicants:
-                if applicant.matching_attendee:
-                    if applicant.matching_attendee.ribbon == c.NO_RIBBON:
-                        applicant.matching_attendee.ribbon = c.PANELIST_RIBBON
-                    if group and not applicant.matching_attendee.group_id:
-                        applicant.matching_attendee.group = group
-                else:
-                    attendee = Attendee(
-                        group=group,
-                        placeholder=True,
-                        ribbon=c.PANELIST_RIBBON,
-                        badge_type=c.ATTENDEE_BADGE,
-                        paid=c.PAID_BY_GROUP if group else c.NEED_NOT_PAY,
-                        first_name=applicant.first_name,
-                        last_name=applicant.last_name,
-                        cellphone=applicant.cellphone,
-                        email=applicant.email
-                    )
-                    if group and applicant.submitter:
-                        leader = attendee
-                    session.add(attendee)
+            if app.status == c.ACCEPTED:
+                leader = None
+                group = Group(name='Panelists for ' + app.name, cost=0, auto_recalc=False) if create_group else None
+                for applicant in app.applicants:
+                    if applicant.matching_attendee:
+                        if applicant.matching_attendee.ribbon == c.NO_RIBBON:
+                            applicant.matching_attendee.ribbon = c.PANELIST_RIBBON
+                        if group and not applicant.matching_attendee.group_id:
+                            applicant.matching_attendee.group = group
+                    else:
+                        attendee = Attendee(
+                            group=group,
+                            placeholder=True,
+                            ribbon=c.PANELIST_RIBBON,
+                            badge_type=c.ATTENDEE_BADGE,
+                            paid=c.PAID_BY_GROUP if group else c.NEED_NOT_PAY,
+                            first_name=applicant.first_name,
+                            last_name=applicant.last_name,
+                            cellphone=applicant.cellphone,
+                            email=applicant.email
+                        )
+                        if group and applicant.submitter:
+                            leader = attendee
+                        session.add(attendee)
 
-            if group:
-                session.add(group)
-                session.commit()
-                group.leader_id = leader.id
-                session.commit()
+                if group:
+                    session.add(group)
+                    session.commit()
+                    group.leader_id = leader.id
+                    session.commit()
 
             raise HTTPRedirect('index?message={}{}{}', app.name, ' was marked as ', app.status_label)
 
         return {
             'app': app,
             'group': create_group
+        }
+
+    def associate(self, session, message='', **params):
+        app = session.panel_application(params)
+        if app.status != c.ACCEPTED:
+            raise HTTPRedirect('index?message={}', 'You cannot associate a non-accepted panel application with an event')
+        elif app.event_id and cherrypy.request.method == 'GET':
+            raise HTTPRedirect('index?message={}{}', 'This panel application is already associated with the event ', app.event.name)
+
+        if cherrypy.request.method == 'POST':
+            if not app.event_id:
+                message = 'You must select an event'
+            else:
+                for attendee in app.matching_attendees:
+                    if not session.query(AssignedPanelist).filter_by(event_id=app.event_id, attendee_id=attendee.id).first():
+                        app.event.assigned_panelists.append(AssignedPanelist(attendee=attendee))
+                raise HTTPRedirect('index?message={}{}{}', app.name, ' was associated with ', app.event.name)
+
+        return {
+            'app': app,
+            'message': message,
+            'panels': [e for e in session.query(Event).filter(Event.location.in_(c.PANEL_ROOMS)).order_by('name').all()]
         }
 
     @csv_file

--- a/panels/templates/emails/panel_app_accepted.txt
+++ b/panels/templates/emails/panel_app_accepted.txt
@@ -6,7 +6,7 @@ Yourself and all panelists will receive free admissions.  If you have not yet re
 
 Important: If you or any others on your panel have purchased badges, {{ c.EVENT_NAME }} will refund the purchase price.  Please let us know if this is the case so we can get your refund sooner. As a reminder {{ c.EVENT_NAME }} will be held {{ c.EPOCH|datetime:"%A, %B %-d" }} through {{ c.ESCHATON|datetime:"%A, %B %-d" }} at {{ c.EVENT_LOCATION }}.
 
-If you have any questions or concerns, please don't hesitate to send them to {{ c.PANELS_EMAIL }}.
+If you have any questions or concerns, please don't hesitate to send them to {{ c.PANELS_EMAIL|email_only }}.
 
 Congratulations again, and we look forward to seeing you at {{ c.EVENT_NAME }}!
 

--- a/panels/templates/emails/panel_app_declined.txt
+++ b/panels/templates/emails/panel_app_declined.txt
@@ -2,7 +2,6 @@
 
 You submitted a panel, "({{ app.name }})", for {{ c.EVENT_NAME }}.  Unfortunately, we did not have enough time this year to accommodate your panel.  We have so many entries that we are unable to accept the majority of them, and we still encourage you to post about meetups where you can join with people to talk about these topics.  {{ c.EVENT_NAME }} is growing and changing every year, and due to our time and space constraints we often have to decline submissions that we wish we could accept, so please do apply again next year.
 
-If you have any questions or concerns, please don't hesitate to send them to {{ c.PANELS_EMAIL }}.
+If you have any questions or concerns, please don't hesitate to send them to {{ c.PANELS_EMAIL|email_only }}.
 
 {{ c.PEGLEGS_EMAIL_SIGNATURE }}
-

--- a/panels/templates/emails/panel_app_scheduled.txt
+++ b/panels/templates/emails/panel_app_scheduled.txt
@@ -1,0 +1,9 @@
+{{ app.submitter.first_name }},
+
+"{{ app.name }}", the panel you submitted for {{ c.EVENT_NAME }}, has been scheduled.  {{ c.EVENT_NAME }} is {{ c.EPOCH|datetime:"%A, %B %-d" }} through {{ c.ESCHATON|datetime:"%A, %B %-d" }}, and your panel is currently scheduled for {% timespan app.event %}.  This scheduling can be changed if absolutely necessary, but it was chosen based on your and others' declared availability.
+
+If you have any questions or concerns, please don't hesitate to send them to {{ c.PANELS_EMAIL|email_only }}.
+
+Congratulations again, and we look forward to seeing you at {{ c.EVENT_NAME }}!
+
+{{ c.PEGLEGS_EMAIL_SIGNATURE }}

--- a/panels/templates/emails/panel_app_waitlisted.txt
+++ b/panels/templates/emails/panel_app_waitlisted.txt
@@ -1,0 +1,7 @@
+{{ app.submitter.first_name }},
+
+Thanks for your interest in putting on a panel for {{ c.EVENT_NAME }}!  Due to the volume of applications we were unable to find a place on our schedule for your panel ({{ app.name }}), but we liked it enough to add it to our waiting list.  Wait-listed candidates will be considered if any of our other panels are cancelled.
+
+Please don't hesitate to let us know if you have any questions or concerns.  Otherwise, we look forward to seeing you at {{ c.EVENT_NAME }}!
+
+{{ c.PEGLEGS_EMAIL_SIGNATURE }}

--- a/panels/templates/panel_app_management/app.html
+++ b/panels/templates/panel_app_management/app.html
@@ -21,6 +21,8 @@
             {% if app.status == c.PENDING %}
                 <a href="mark?id={{ app.id }}&status={{ c.ACCEPTED }}">Accept</a>
                 or
+                <a href="mark?id={{ app.id }}&status={{ c.WAITLISTED }}">Waitlist</a>
+                or
                 <a href="mark?id={{ app.id }}&status={{ c.DECLINED }}">Decline</a>
             {% else %}
                 <b>{{ app.status_label }}</b>
@@ -32,7 +34,11 @@
         <div class="form-group">
             <label class="col-sm-3 control-label">Event:</label>
             <div class="col-sm-6 app-display">
-                <i>this is not implemented yet, but in a few days this is where you'll click to associate this panel with an event on the schedule</i>
+                {% if app.event_id %}
+                    <a href="../schedule/form?id={{ app.event_id }}">{{ app.event.name }}</a>
+                {% else %}
+                    <a href="associate?id={{ app.id }}">Click here</a> to associate this application with an event on the schedule
+                {% endif %}
             </div>
         </div>
     {% endif %}

--- a/panels/templates/panel_app_management/associate.html
+++ b/panels/templates/panel_app_management/associate.html
@@ -1,0 +1,41 @@
+{% extends "base-admin.html" %}
+{% block title %}Panel Submission{% endblock %}}
+{% block content %}
+
+<h2>Associate "{{ app.name }}" with an event on the schedule</h2>
+
+Use the form below to associate this application with an event on the schedule.  Doing so will have two effects:
+<br/> <br/>
+<ol>
+    <li>
+        The primary contact for this panel ({{ app.submitter.full_name }}) will be emailed to let them know the start/stop time
+        of their panel and its location (e.g. "Panels 1").
+        <br/> </br>
+    </li>
+    <li>
+        Each panelist will be added to the list of assigned panelists for this event, which is mainly used to detect when
+        multiple panels have been scheduled simultaneously with the same people.  Here is a list of everyone who will be
+        added as an assigned panelist to this event:
+        <ul>
+        {% for attendee in app.matching_attendees %}
+            <li>{{ attendee|form_link }}</li>
+        {% endfor %}
+        </ul>
+        <br/>
+    </li>
+</ol>
+
+<form method="post" action="associate">
+    {% csrf_token %}
+    <input type="hidden" name="id" value="{{ app.id }}" />
+    <select name="event_id">
+        <option value="">Select an event</option>
+        {% for event in panels %}
+            <option value="{{ event.id }}">{{ event.name }} ({% timespan event %})</option>
+        {% endfor %}
+    </select>
+    <input type="submit" value="Associate" />
+</form>
+
+
+{% endblock %}

--- a/panels/templates/panel_app_management/index.html
+++ b/panels/templates/panel_app_management/index.html
@@ -37,7 +37,13 @@
                 not voted yet
             {% endif %}
         </td>
-        <td>{{ app.status_label }}</td>
+        <td>
+            {% if app.event_id %}
+                <a href="../schedule/form?id={{ app.event_id }}">{{ app.status_label }}</a>
+            {% else %}
+                {{ app.status_label }}
+            {% endif %}
+        </td>
     </tr>
 {% endfor %}
 </tbody>


### PR DESCRIPTION
I also added the waitlisted status with associated emails.

This involved adding a new foreign key, which involved running the following SQL commands on the staging and production servers:

``` sql
ALTER TABLE panel_application ADD COLUMN event_id UUID NULL;
ALTER TABLE panel_application ADD CONSTRAINT panel_application_event_id_fkey FOREIGN KEY (event_id) REFERENCES event (id);
```
