### PR TITLE
added page with panelists owed refunds

### DIFF
--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -210,3 +210,12 @@ class Root:
             'events':  events,
             'message': message
         }
+
+    def panelists_owed_refunds(self, session):
+        return {
+            'panelists': [a for a in session.query(Attendee)
+                                            .filter_by(ribbon=c.PANELIST_RIBBON)
+                                            .options(joinedload(Attendee.group))
+                                            .order_by(Attendee.full_name).all()
+                          if a.paid == c.HAS_PAID or a.paid == c.PAID_BY_GROUP and a.group and a.group.amount_paid]
+        }

--- a/panels/templates/schedule/panelists_owed_refunds.html
+++ b/panels/templates/schedule/panelists_owed_refunds.html
@@ -1,0 +1,20 @@
+{% extends "base-admin.html" %}
+{% block title %}Panelists Owed Refunds{% endblock %}
+{% block content %}
+
+<h2>Panelists Owed Refunds</h2>
+
+The following is a list of {{ panelists|length }} attendee{{ panelists|length|pluralize }} with panelist ribbons who have paid
+and not been refunded:
+<ul>
+{% for attendee in panelists %}
+    <li>
+        {{ attendee|form_link }}
+        {% if attendee.group_id %}
+            (<a href="../groups/form?id={{ attendee.group_id }}">{{ attendee.group.name }}</a>)
+        {% endif %}
+    </li>
+{% endfor %}
+</ul>
+
+{% endblock %}


### PR DESCRIPTION
Since these are refunds we can just do in advance, I figured it would be useful for a report that just shows all of them so we can run down the list and process the refunds.
