### PR TITLE
Gracefully handle missing panel rooms in INI

### DIFF
--- a/panels/config.py
+++ b/panels/config.py
@@ -15,7 +15,7 @@ invalid_panel_rooms = [room for room in c.PANEL_ROOMS if not getattr(c, room.upp
 
 for room in invalid_panel_rooms:
     log.warning('panels plugin: panels_room config problem: '
-                'Ignoring "' + room.upper() + '" because it was not also found in [[event_location]] section.')
+                'Ignoring {!r} because it was not also found in [[event_location]] section.'.format(room.upper()))
 
 c.PANEL_ROOMS = [getattr(c, room.upper()) for room in c.PANEL_ROOMS if room not in invalid_panel_rooms]
 

--- a/panels/config.py
+++ b/panels/config.py
@@ -11,7 +11,13 @@ c.ORDERED_EVENT_LOCS = [loc for loc, desc in c.EVENT_LOCATION_OPTS]
 c.EVENT_BOOKED = {'colspan': 0}
 c.EVENT_OPEN   = {'colspan': 1}
 
-c.PANEL_ROOMS = [getattr(c, room.upper()) for room in c.PANEL_ROOMS]
+invalid_panel_rooms = [room for room in c.PANEL_ROOMS if not getattr(c, room.upper(), None)]
+
+for room in invalid_panel_rooms:
+    log.warning('panels plugin: panels_room config problem: '
+                'Ignoring "' + room.upper() + '" because it was not also found in [[event_location]] section.')
+
+c.PANEL_ROOMS = [getattr(c, room.upper()) for room in c.PANEL_ROOMS if room not in invalid_panel_rooms]
 
 # This can go away if/when we implement plugin enum merging
 c.ACCESS.update(c.PANEL_ACCESS_LEVELS)


### PR DESCRIPTION
The panels plugin keeps track of what it calls "panel rooms"

These are supposed to also exist in "event_locations" in the main INI, but when they don't, we were crashing instead of saying something useful.  It took me a while to figure out why this was happening both with Magstock and MagLabs, so, doing two things here:

 1) Log a warning when a problem is detected that tells you where to go to fix it
 2) Gracefully handle the situation without crashing, so this doesn't stop the app from starting up
