### PR TITLE
removed panel voting and added new fields to application form

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -4,5 +4,5 @@ expected_response = "December 2016"
 event_location = "the Gaylord National Resort and Convention Center in National Harbor, Maryland"
 
 [dates]
-panel_app_deadline = "2016-10-30"
+panel_app_deadline = "2016-10-31"
 

--- a/panels/configspec.ini
+++ b/panels/configspec.ini
@@ -52,10 +52,6 @@ performance = string(default="Scripted or Improv Live Performance")
 participation = string(default="Audience participation (like a game)")
 other = string(default="Other")
 
-[[panel_vote]]
-accept = string(default="Accept")
-decline = string(default="Reject")
-
 [[panel_app_status]]
 pending = string(default="Pending")
 accepted = string(default="Accepted")

--- a/panels/models.py
+++ b/panels/models.py
@@ -113,4 +113,3 @@ class PanelApplicant(MagModel):
             func.lower(Attendee.last_name) == self.last_name.lower(),
             func.lower(Attendee.email) == self.email.lower()
         ).first()
-

--- a/panels/site_sections/panel_app_management.py
+++ b/panels/site_sections/panel_app_management.py
@@ -4,40 +4,15 @@ from panels import *
 @all_renderable(c.PANEL_APPS)
 class Root:
     def index(self, session, message=''):
-        curr_admin_votes = {pv.application: pv for pv in session.admin_attendee().admin_account.panel_votes}
-        apps = session.panel_apps()
-        for app in apps:
-            app.curr_admin_vote = curr_admin_votes.get(app)
-
         return {
-            'apps': apps,
             'message': message,
-            'vote_count': len(curr_admin_votes)
+            'apps': session.panel_apps()
         }
 
-    def app(self, session, id, message='', csrf_token='', vote=None, explanation=None):
-        app = session.panel_application(id)
-        account = session.admin_attendee().admin_account
-        panel_vote = session.query(PanelVote).filter_by(account_id=account.id, app_id=app.id).first()
-        if not panel_vote:
-            panel_vote = PanelVote(account_id=account.id, app_id=app.id)
-
-        if vote is not None:
-            check_csrf(csrf_token)
-            panel_vote.vote = int(vote or 0)
-            panel_vote.explanation = explanation.strip()
-            if not panel_vote.vote:
-                message = 'You did not indicate your vote'
-            elif not panel_vote.explanation:
-                message = 'You must provide an explanation of your vote'
-            else:
-                session.add(panel_vote)
-                raise HTTPRedirect('index?message={}{}', 'Vote cast for ', app.name)
-
+    def app(self, session, id, message='', csrf_token='', explanation=None):
         return {
-            'app': app,
             'message': message,
-            'panel_vote': panel_vote
+            'app': session.panel_application(id)
         }
 
     def mark(self, session, status, **params):

--- a/panels/site_sections/panel_applications.py
+++ b/panels/site_sections/panel_applications.py
@@ -28,6 +28,8 @@ class Root:
                     message = 'You must check the box to verify you understand that you will not hear back until {}'.format(c.EXPECTED_RESPONSE)
                 elif 'verify_tos' not in params:
                     message = 'You must accept our Terms of Accomodation'
+                elif other_panelists and 'verify_poc' not in params:
+                    message = 'You must agree to being the point of contact for your group'
                 else:
                     session.add_all([app, panelist] + other_panelists)
                     raise HTTPRedirect('index?message={}', 'Your panel application has been submitted')
@@ -39,6 +41,7 @@ class Root:
             'ops_count': len(other_panelists),
             'other_panelists': other_panelists,
             'verify_tos': params.get('verify_tos'),
+            'verify_poc': params.get('verify_pos'),
             'verify_waiting': params.get('verify_waiting'),
             'verify_unavailable': params.get('verify_unavailable')
         }

--- a/panels/templates/panel_app_management/app.html
+++ b/panels/templates/panel_app_management/app.html
@@ -11,10 +11,7 @@
 
 <h2>Panel Applications</h2>
 
-<form method="post" action="app" role="form" class="form-horizontal">
-    <input type="hidden" name="id" value="{{ app.id }}" />
-    {% csrf_token %}
-
+<form class="form-horizontal">
     <div class="form-group">
         <label class="col-sm-3 control-label">Panel Status:</label>
         <div class="col-sm-6 app-display">
@@ -93,6 +90,15 @@
         </div>
     {% endif %}
 
+    {% if app.panelist_bringing %}
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Panelist is bringing:</label>
+            <div class="col-sm-6 app-display">
+                {{ app.panelist_bringing }}
+            </div>
+        </div>
+    {% endif %}
+
     {% if app.affiliations %}
         <div class="form-group">
             <label class="col-sm-3 control-label">Affiliations:</label>
@@ -124,31 +130,6 @@
             {% endfor %}
         </div>
     </div>
-
-    {% if app.status == c.PENDING %}
-        <div class="form-group">
-            <label class="col-sm-3 control-label">Your Vote:</label>
-            <div class="col-sm-6">
-                <select name="vote" class="form-control">
-                    <option value="">How Do You Vote?</option>
-                    {% options c.PANEL_VOTE_OPTS panel_vote.vote %}
-                </select>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <label class="col-sm-3 control-label">Explanation:</label>
-            <div class="col-sm-6">
-                <textarea class="form-control" name="explanation" rows="4">{{ panel_vote.explanation }}</textarea>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <div class="col-sm-6 col-sm-offset-3">
-                <button type="submit" class="btn btn-primary">Cast Your Vote</button>
-            </div>
-        </div>
-    {% endif %}
 </form>
 
 {% endblock %}

--- a/panels/templates/panel_app_management/index.html
+++ b/panels/templates/panel_app_management/index.html
@@ -4,10 +4,6 @@
 
 <h2>Panel Applications</h2>
 
-<div style="text-align:center">
-    You have cast {{ vote_count }} votes out of {{ apps|length }} applications.
-</div>
-
 <table class="table datatable" data-page-length="-1">
 <thead>
     <tr>
@@ -15,9 +11,6 @@
         <th>Panel Type</th>
         <th>Submitted By</th>
         <th>Applied</th>
-        <th>Yes Votes</th>
-        <th>No Votes</th>
-        <th>My Vote</th>
         <th>Status</th>
     </tr>
 </thead>
@@ -28,15 +21,6 @@
         <td>{{ app.presentation_label }}</td>
         <td>{{ app.submitter.full_name }}</td>
         <td>{{ app.applied_local|datetime:"%Y-%m-%d" }}</td>
-        <td>{{ app.vote_counts.accept }}</td>
-        <td>{{ app.vote_counts.decline }}</td>
-        <td>
-            {% if app.curr_admin_vote %}
-                {{ app.curr_admin_vote.vote_label }}
-            {% else %}
-                not voted yet
-            {% endif %}
-        </td>
         <td>
             {% if app.event_id %}
                 <a href="../schedule/form?id={{ app.event_id }}">{{ app.status_label }}</a>

--- a/panels/templates/panel_applications/index.html
+++ b/panels/templates/panel_applications/index.html
@@ -13,6 +13,9 @@
     var showOrHideOtherPresentation = function () {
         setVisible($.field('other_presentation').parents('.form-group'), $.val('presentation') === {{ c.OTHER }});
     };
+    var showOrHidePOC = function () {
+        setVisible('#point_of_contact', $.val('other_panelists'));
+    };
     var showOrHideOtherPanelists = function () {
         var count = $.val('other_panelists');
         var $ops = $('#other-panelist-data tbody tr');
@@ -33,12 +36,14 @@
 
     $(function () {
         $('<br/>').insertBefore('nobr');
+        showOrHidePOC();
         showOrHideHeldBefore();
         showOrHideAffiliations();
         showOrHideOtherPanelists();
         showOrHideOtherPresentation();
         $.field('held_before').on('click', showOrHideHeldBefore);
         $.field('has_affiliations').on('click', showOrHideAffiliations);
+        $.field('other_panelists').on('change', showOrHidePOC);
         $.field('other_panelists').on('change', showOrHideOtherPanelists);
         $.field('presentation').on('change', showOrHideOtherPresentation);
     });
@@ -101,6 +106,14 @@
                     <input class="form-control" type="text" name="name" value="{{ app.name }}" />
                 </div>
             </div>
+            <div class="form-group">
+                <label class="col-sm-2 control-label">Type of Panel:</label>
+                <div class="col-sm-6">
+                    <select name="presentation" class="form-control">
+                        {% options c.PRESENTATION_OPTS app.presentation %}
+                    </select>
+                </div>
+            </div>
             <div class="form-group" style="margin-bottom:0px">
                 <label class="col-sm-2 control-label">Panel Description</label>
                 <div class="col-sm-6">
@@ -150,7 +163,7 @@
 
             <h3>Additional Information</h3>
             <div class="form-group" style="margin-bottom:0px">
-                <label class="col-sm-2 control-label">When are you unavailable?.</label>
+                <label class="col-sm-2 control-label">When are you unavailable?</label>
                 <div class="col-sm-6">
                     <textarea class="form-control" name="unavailable" rows="4">{{ app.unavailable }}</textarea>
                 </div>
@@ -175,14 +188,6 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">Type of Panel:</label>
-                <div class="col-sm-6">
-                    <select name="presentation" class="form-control">
-                        {% options c.PRESENTATION_OPTS app.presentation %}
-                    </select>
-                </div>
-            </div>
-            <div class="form-group">
                 <label class="col-sm-2 control-label">Please Describe:</label>
                 <div class="col-sm-6">
                     <input type="input" class="form-control" name="other_presentation" value="{{ app.other_presentation }}" />
@@ -194,6 +199,12 @@
                     Check the following technical needs that apply. Panel rooms will by default have VGA compatible projector with 3.5mm (1/8") audio, and a local PA with enough microphones setup.
                     {% checkgroup app.tech_needs %} <br/>
                     Other: <input type="text" name="other_tech_needs" value="{{ app.other_tech_needs }}" />
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-2 control-label">What are you bringing?</label>
+                <div class="col-sm-6">
+                    <input type="input" class="form-control" name="panelist_bringing" value="{{ app.panelist_bringing }}" placeholder="Windows laptop, Macbook, gaming console, etc" />
                 </div>
             </div>
 
@@ -227,6 +238,13 @@
                     {% endfor %}
                 </tbody>
             </table>
+            <div id="point_of_contact" class="form-group" style="display:none">
+                <label class="col-sm-2 control-label">&nbsp;</label>
+                <div class="col-sm-6">
+                    I understand that by submitting this application, I am designating myself as the team leader and primary point of contact for this panel. I further understand that if I need to add or change panelists for this event I may be required to provide justification, and that this will be approved at the sole discretion of {{ c.EVENT_NAME }} Staff. <br/>
+                    <input type="checkbox" name="verify_poc" {% if verify_poc %}checked{% endif %} /> I have read and agree to the terms above.
+                </div>
+            </div>
 
             <h3>Panelist Terms of Accomodation</h3>
             <div class="form-group">


### PR DESCRIPTION
Three changes, requested by the panel folks:

1) Eliminate the voting component.  This was never used, and is kind of clunky anyway.  There's some discussion of better ways to go about this, but for not it's just not useful.

2) Moved a couple of fields around on the form.

3) Updated the default deadline (eventually we ned to puppetize that).

4) Added a new field for the applicant to indicate what tech they're bringing, e.g. a Macbook or a Windows laptop or a game console, etc.  This required me to run the following, which I already did on the labs and supermag servers:

``` sql
ALTER TABLE panel_application ADD COLUMN panelist_bringing TEXT NOT NULL DEFAULT '';
```

Though since those tables were empty I could have also just dropped them and let the system re-create them, but this was easier since the PR hasn't been accepted yet.
