### PR TITLE
Add redirect if alt_schedule_url is set

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -3,6 +3,8 @@ expected_response = "December 2016"
 
 event_location = "the Gaylord National Resort and Convention Center in National Harbor, Maryland"
 
+alt_schedule_url = "https://guidebook.com/guide/77688/schedule/"
+
 [dates]
 panel_app_deadline = "2016-10-31"
 

--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -7,7 +7,10 @@ class Root:
     @cached
     def index(self, session, message=''):
         if c.HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
-            return "The " + c.EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."
+            if c.ALT_SCHEDULE_URL:
+                raise HTTPRedirect(c.ALT_SCHEDULE_URL)
+            else:
+                return "The " + c.EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."
 
         schedule = defaultdict(lambda: defaultdict(list))
         for event in session.query(Event).all():

--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -7,10 +7,10 @@ class Root:
     @cached
     def index(self, session, message=''):
         if c.HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
-            if c.ALT_SCHEDULE_URL:
-                raise HTTPRedirect(c.ALT_SCHEDULE_URL)
-            else:
-                return "The " + c.EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."
+            return "The " + c.EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."
+
+        if c.ALT_SCHEDULE_URL:
+            raise HTTPRedirect(c.ALT_SCHEDULE_URL)
 
         schedule = defaultdict(lambda: defaultdict(list))
         for event in session.query(Event).all():


### PR DESCRIPTION
For MAGLabs this year, we wanted to simply disable the schedule permanently and use Guidebook. However, this can be confusing for people who are used to accessing the schedule URL. This now gives events the ability to redirect to another URL instead.
