### PR TITLE
remove outdated/hardcoded guidebook URL

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -3,7 +3,7 @@ expected_response = "December 2016"
 
 event_location = "the Gaylord National Resort and Convention Center in National Harbor, Maryland"
 
-alt_schedule_url = "https://guidebook.com/guide/77688/schedule/"
+alt_schedule_url = ""
 
 [dates]
 panel_app_deadline = "2016-10-31"


### PR DESCRIPTION
was hardcoded to maglabs, and is now a puppet option