### PR TITLE
fixed panelist schedule email

### DIFF
--- a/panels/automated_emails.py
+++ b/panels/automated_emails.py
@@ -34,4 +34,5 @@ PanelAppEmail('Your {EVENT_NAME} Panel Has Been Scheduled: <PANEL_NAME>', 'panel
 
 AutomatedEmail(Attendee, 'Your {EVENT_NAME} Event Schedule', 'panelist_schedule.txt',
                lambda a: a.assigned_panelists,
-               ident='event_schedule')
+               ident='event_schedule',
+               sender=c.PANELS_EMAIL)

--- a/panels/templates/emails/panelist_schedule.txt
+++ b/panels/templates/emails/panelist_schedule.txt
@@ -1,5 +1,5 @@
 {{ attendee.first_name }},
 
-You are signed up to present {{ attendee.assigned_panelists|length }} panel{{ {{ attendee.assigned_panelists|length|pluralize }} at this coming {{ c.EVENT_NAME }}.  You can find a printable panel schedule at {{ c.URL_BASE }}/schedule/panelist_schedule?id={{ attendee.id }}
+You are signed up to present {{ attendee.assigned_panelists|length }} panel{{ attendee.assigned_panelists|length|pluralize }} at this coming {{ c.EVENT_NAME }}.  You can find a printable panel schedule at {{ c.URL_BASE }}/schedule/panelist_schedule?id={{ attendee.id }}
 
 {{ c.PANELS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
Two fixes:

1) There was a superfluous ``{{`` in the email body, which I imagine must have gotten there due to an accidental copy/paste after I tested it locally.  We're only about to send out the email this week which is why we haven't noticed until now.

2) The email sender wasn't set to be from the panels department, which I've fixed.  RegSupport definitely shouldn't be getting replies to this email!