### PR TITLE
Restore ability to view internal uber schedule

### DIFF
--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -9,9 +9,6 @@ class Root:
         if c.HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
             return "The " + c.EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."
 
-        if c.ALT_SCHEDULE_URL:
-            raise HTTPRedirect(c.ALT_SCHEDULE_URL)
-
         schedule = defaultdict(lambda: defaultdict(list))
         for event in session.query(Event).all():
             schedule[event.start_time_local][event.location].append(event)
@@ -51,6 +48,13 @@ class Root:
             'schedule':  sorted(schedule.items()),
             'max_simul': sorted(max_simul, key=lambda tup: c.ORDERED_EVENT_LOCS.index(tup[0]))
         }
+
+    @unrestricted
+    def guidebook(self, session):
+        if c.ALT_SCHEDULE_URL:
+            raise HTTPRedirect(c.ALT_SCHEDULE_URL)
+        else:
+            raise HTTPRedirect("index")
 
     @unrestricted
     @csv_file

--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -10,6 +10,7 @@ class Root:
         else:
             raise HTTPRedirect("internal")
 
+    @cached
     def internal(self, session, message=''):
         if c.HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
             return "The " + c.EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."

--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -4,8 +4,13 @@ from panels import *
 @all_renderable(c.STUFF)
 class Root:
     @unrestricted
-    @cached
     def index(self, session, message=''):
+        if c.ALT_SCHEDULE_URL:
+            raise HTTPRedirect(c.ALT_SCHEDULE_URL)
+        else:
+            raise HTTPRedirect("internal")
+
+    def internal(self, session, message=''):
         if c.HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
             return "The " + c.EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."
 
@@ -48,13 +53,6 @@ class Root:
             'schedule':  sorted(schedule.items()),
             'max_simul': sorted(max_simul, key=lambda tup: c.ORDERED_EVENT_LOCS.index(tup[0]))
         }
-
-    @unrestricted
-    def guidebook(self, session):
-        if c.ALT_SCHEDULE_URL:
-            raise HTTPRedirect(c.ALT_SCHEDULE_URL)
-        else:
-            raise HTTPRedirect("index")
 
     @unrestricted
     @csv_file


### PR DESCRIPTION
To be merged with PR in Ubersystem.

This will separate the guidebook and internal schedule into two functions, allowing staffers to view the previously used internal one. Some prefer it.