### PR TITLE
damn you utctimetuple why did I need to call you

### DIFF
--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -129,8 +129,8 @@ class Root:
                 'location': event.location_label,
                 'start': event.start_time_local.strftime('%I%p %a').lstrip('0'),
                 'end': event.end_time_local.strftime('%I%p %a').lstrip('0'),
-                'start_unix': int(mktime(event.start_time.timetuple())),
-                'end_unix': int(mktime(event.end_time.timetuple())),
+                'start_unix': int(mktime(event.start_time.utctimetuple())),
+                'end_unix': int(mktime(event.end_time.utctimetuple())),
                 'duration': event.minutes,
                 'description': event.description,
                 'panelists': [panelist.attendee.full_name for panelist in event.assigned_panelists]


### PR DESCRIPTION
I'd previously assumed that if you called ``.timetuple()`` on a ``UTC``-timezoned datetime object that the result would be a utc time tuple.  However, apparently you still need to call ``.utctimetuple()`` even in this case or Python will do a silent timezone conversion for you.  Bleh.