### PR TITLE
Remove base-admin.html

### DIFF
--- a/panels/templates/panel_app_management/app.html
+++ b/panels/templates/panel_app_management/app.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panel Submission{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/assigned_to.html
+++ b/panels/templates/panel_app_management/assigned_to.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}{{ attendee.full_name }}'s panel applications{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/associate.html
+++ b/panels/templates/panel_app_management/associate.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panel Submission{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/badges.html
+++ b/panels/templates/panel_app_management/badges.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panelist Badges{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/feedback_report.html
+++ b/panels/templates/panel_app_management/feedback_report.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}All Panel Feedback{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/form.html
+++ b/panels/templates/panel_app_management/form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Edit Panel Application{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/index.html
+++ b/panels/templates/panel_app_management/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panel Submissions{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/mark.html
+++ b/panels/templates/panel_app_management/mark.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panel Status{% endblock %}}
 {% block content %}
 

--- a/panels/templates/panel_app_management/panel_feedback.html
+++ b/panels/templates/panel_app_management/panel_feedback.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panel Feedback{% endblock %}}
 {% block content %}
 

--- a/panels/templates/schedule/edit.html
+++ b/panels/templates/schedule/edit.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Schedule{% endblock %}
 {% block content %}
 

--- a/panels/templates/schedule/form.html
+++ b/panels/templates/schedule/form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Schedule{% endblock %}
 {% block content %}
 

--- a/panels/templates/schedule/internal.html
+++ b/panels/templates/schedule/internal.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Schedule{% endblock %}
 {% block backlink %}
     {% if c.HAS_STUFF_ACCESS %}

--- a/panels/templates/schedule/inventory.html
+++ b/panels/templates/schedule/inventory.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Inventory Requirements{% endblock %}
 {% block content %}
 

--- a/panels/templates/schedule/jobs.html
+++ b/panels/templates/schedule/jobs.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Jobs by Event{% endblock %}
 {% block content %}
 {% with page = 3 %}

--- a/panels/templates/schedule/panelists_owed_refunds.html
+++ b/panels/templates/schedule/panelists_owed_refunds.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panelists Owed Refunds{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.