### PR TITLE
Allows more liberal movement between panel app status.

### DIFF
--- a/panels/templates/panel_app_management/app.html
+++ b/panels/templates/panel_app_management/app.html
@@ -20,21 +20,19 @@
                 <input type="hidden" name="id" value="{{ app.id }}" />
                 {% if app.status != c.PENDING %}
                     <b>{{ app.status_label }}</b>
-                    {% if app.status != c.CANCELLED %}
-                        <br/>Change:
-                    {% endif %}
+                    <br/>Change:
                 {% endif %}
-                {% if app.status != c.ACCEPTED and app.status != c.CANCELLED %}
+                {% if app.status != c.ACCEPTED %}
                     <button name="status" value="{{ c.ACCEPTED }}">Accept</button>
                 {% endif %}
-                {% if app.status != c.WAITLISTED and app.status != c.CANCELLED %}
+                {% if app.status != c.WAITLISTED %}
                     <button name="status" value="{{ c.WAITLISTED }}">Waitlist</button>
                 {% endif %}
-                {% if app.status != c.DECLINED and app.status != c.CANCELLED %}
+                {% if app.status != c.DECLINED %}
                     <button name="status" value="{{ c.DECLINED }}">Decline</button>
                 {% endif %}
                 {% if app.status == c.ACCEPTED %}
-                    <button name="status" value="{{ c.CANCELLED }}">Cancel Acceptance</button>
+                    <button name="status" value="{{ c.CANCELLED }}">Cancel Panel</button>
                 {% endif %}
                 <br/>
                 {{ macros.popup_link("email_statuses", "Will this trigger an email?") }}

--- a/panels/templates/panel_app_management/form.html
+++ b/panels/templates/panel_app_management/form.html
@@ -4,84 +4,91 @@
 
 <div class="masthead"></div>
 <div class="panel panel-default">
+  <div class="panel-body">
     <h2>Edit Panel</h2>
     <form method="post" action="form" class="form-horizontal" role="form">
         {{ csrf_token() }}
         <input type="hidden" name="id" value="{{ app.id }}" />
         <div class="form-group">
-            <label class="col-sm-2 control-label">Panel Name:</label>
+            <label class="col-sm-3 control-label">Panel Name:</label>
             <div class="col-sm-6">
                 <input class="form-control" type="text" name="name" value="{{ app.name }}" />
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">Type of Panel:</label>
+            <label class="col-sm-3 control-label">Type of Panel:</label>
             <div class="col-sm-6">
                 <select name="presentation" class="form-control">
                     {{ options(c.PRESENTATION_OPTS, app.presentation) }}
                 </select>
             </div>
         </div>
-        <div class="form-group" style="margin-bottom:0px">
-            <label class="col-sm-2 control-label">Panel Description</label>
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Panel Description</label>
             <div class="col-sm-6">
                 <textarea class="form-control" name="description" rows="4">{{ app.description }}</textarea>
             </div>
-        </div>
-        <div class="form-group">
-            <p class="help-block col-sm-6 col-sm-offset-2">
+            <p class="help-block col-sm-9 col-sm-offset-3">
                 Will appear as a subheading on the schedule. 200 words max.
             </p>
         </div>
-        <div class="form-group" style="margin-bottom:0px">
-            <label class="col-sm-2 control-label">Expected Panel Length:</label>
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Expected Panel Length:</label>
             <div class="col-sm-6">
                 <input class="form-control" type="text" name="length" value="{{ app.length }}" />
             </div>
-        </div>
-        <div class="form-group">
-            <p class="help-block col-sm-6 col-sm-offset-2">
+            <p class="help-block col-sm-9 col-sm-offset-3">
                 An hour is typical, including time for Q&A.
             </p>
         </div>
         <div class="form-group" style="display:none">
-            <label class="col-sm-2 control-label">Past Attendance:</label>
+            <label class="col-sm-3 control-label">Past Attendance:</label>
             <div class="col-sm-6">
                 <textarea class="form-control" name="past_attendance" rows="4">{{ app.past_attendance }}</textarea>
             </div>
         </div>
         <div class="form-group" style="display:none">
-            <label class="col-sm-2 control-label">Affiliations:</label>
+            <label class="col-sm-3 control-label">Affiliations:</label>
             <div class="col-sm-6">
                 <textarea class="form-control" name="affiliations" rows="4">{{ app.affiliations }}</textarea>
             </div>
         </div>
-        <div class="form-group" style="margin-bottom:0px">
-            <label class="col-sm-2 control-label">Unavailable:</label>
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Unavailable:</label>
             <div class="col-sm-6">
                 <textarea class="form-control" name="unavailable" rows="4">{{ app.unavailable }}</textarea>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">Technical Needs</label>
-            <div class="col-sm-6">
-                Check the following technical needs that apply. Panel rooms will by default have VGA compatible projector with 3.5mm (1/8") audio, and a local PA with enough microphones setup.
-                {{ macros.checkgroup(app, 'tech_needs') }} <br/>
-                Other: <input type="text" name="other_tech_needs" value="{{ app.other_tech_needs }}" />
+            <label class="col-sm-3 control-label">Technical Needs</label>
+            <div class="col-sm-9">
+                <p>
+                    Check the following technical needs that apply. Panel
+                    rooms will by default have VGA compatible projector
+                    with 3.5mm (1/8") audio, and a local PA with enough
+                    microphones setup.
+                </p>
+                <p>
+                    {{ macros.checkgroup(app, 'tech_needs') }}
+                </p>
+                <p>
+                  Other: <input type="text" name="other_tech_needs" value="{{ app.other_tech_needs }}" />
+                </p>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">What are you bringing?</label>
+            <label class="col-sm-3 control-label">What are you bringing?</label>
             <div class="col-sm-6">
                 <input type="input" class="form-control" name="panelist_bringing" value="{{ app.panelist_bringing }}" placeholder="Windows laptop, Macbook, gaming console, etc" />
             </div>
         </div>
         <div class="form-group">
-            <div class="col-sm-6 col-sm-offset-2">
+            <div class="col-sm-6 col-sm-offset-3">
                 <button type="submit" class="btn btn-primary">Update</button>
             </div>
         </div>
     </form>
+  </div>
 </div>
 
 {% endblock %}

--- a/panels/templates/panel_app_management/panel_feedback.html
+++ b/panels/templates/panel_app_management/panel_feedback.html
@@ -15,6 +15,7 @@
 
 <div class="masthead"></div>
 <div class="panel panel-default">
+  <div class="panel-body">
     <h2>Feedback for {{ event.name }}</h2>
     <form method="post" action="panel_feedback" class="form-horizontal" role="form">
         {{ csrf_token() }}
@@ -56,6 +57,7 @@
             </div>
         </div>
     </form>
+  </div>
 </div>
 
 {% endblock %}

--- a/panels/templates/panel_applications/index.html
+++ b/panels/templates/panel_applications/index.html
@@ -51,6 +51,7 @@
 
 <div class="masthead"></div>
 <div class="panel panel-default">
+  <div class="panel-body">
     <h2>{{ c.EVENT_NAME }} Panel Submission Form</h2>
 
     {% if c.AFTER_PANEL_APP_DEADLINE and not c.HAS_PANEL_APPS_ACCESS %}
@@ -77,92 +78,104 @@
 
             <h3>Personal Information</h3>
             <div class="form-group">
-                <label class="col-sm-2 control-label">First Name:</label>
+                <label class="col-sm-3 control-label">First Name:</label>
                 <div class="col-sm-6">
                     <input class="form-control" type="text" class="focus" name="first_name" value="{{ panelist.first_name }}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">Last Name:</label>
+                <label class="col-sm-3 control-label">Last Name:</label>
                 <div class="col-sm-6">
                     <input class="form-control" type="text" name="last_name" value="{{ panelist.last_name }}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">Email:</label>
+                <label class="col-sm-3 control-label">Email:</label>
                 <div class="col-sm-6">
                     <input class="form-control" type="text" name="email" value="{{ panelist.email }}" />
                 </div>
             </div>
             <div class="form-group" style="margin-bottom:0px">
-                <label class="col-sm-2 control-label">Phone Number:</label>
+                <label class="col-sm-3 control-label">Phone Number:</label>
                 <div class="col-sm-6">
                     <input class="form-control" type="text" name="cellphone" value="{{ panelist.cellphone }}" />
                 </div>
             </div>
             <div class="form-group">
-                <p class="help-block col-sm-6 col-sm-offset-2">
+                <p class="help-block col-sm-9 col-sm-offset-3">
                     Please make this the phone number at which we can most easily reach you before the event regarding your panel.
                 </p>
             </div>
 
             <h3>Panel Information</h3>
             <div class="form-group">
-                <label class="col-sm-2 control-label">Panel Name:</label>
+                <label class="col-sm-3 control-label">Panel Name:</label>
                 <div class="col-sm-6">
                     <input class="form-control" type="text" name="name" value="{{ app.name }}" />
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">Type of Panel:</label>
+                <label class="col-sm-3 control-label">Type of Panel:</label>
                 <div class="col-sm-6">
                     <select name="presentation" class="form-control">
                         {{ options(c.PRESENTATION_OPTS, app.presentation) }}
                     </select>
                 </div>
             </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Please Describe:</label>
+                <div class="col-sm-6">
+                    <input type="input" class="form-control" name="other_presentation" value="{{ app.other_presentation }}" />
+                </div>
+            </div>
             <div class="form-group" style="margin-bottom:0px">
-                <label class="col-sm-2 control-label">Panel Description</label>
+                <label class="col-sm-3 control-label">Panel Description</label>
                 <div class="col-sm-6">
                     <textarea class="form-control" name="description" rows="4">{{ app.description }}</textarea>
                 </div>
             </div>
             <div class="form-group">
-                <p class="help-block col-sm-6 col-sm-offset-2">
+                <p class="help-block col-sm-9 col-sm-offset-3">
                     Will appear as a subheading on the schedule. 200 words max.
                 </p>
             </div>
             <div class="form-group" style="margin-bottom:0px">
-                <label class="col-sm-2 control-label">Expected Panel Length:</label>
+                <label class="col-sm-3 control-label">Expected Panel Length:</label>
                 <div class="col-sm-6">
                     <input class="form-control" type="text" name="length" value="{{ app.length }}" />
                 </div>
             </div>
             <div class="form-group">
-                <p class="help-block col-sm-6 col-sm-offset-2">
+                <p class="help-block col-sm-9 col-sm-offset-3">
                     An hour is typical, including time for Q&A.
                 </p>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">&nbsp</label>
+                <label class="col-sm-3 control-label">&nbsp</label>
                 <div class="col-sm-6">
-                    <input type="checkbox" name='held_before' {% if app.past_attendance %}checked{% endif %} /> Have you held this panel before?
+                    <label class="checkbox-label" style="font-weight: normal;">
+                      <input type="checkbox" name='held_before' {% if app.past_attendance %}checked{% endif %} />
+                      Have you held this panel before?
+                    </label>
                 </div>
             </div>
             <div class="form-group" style="display:none">
-                <label class="col-sm-2 control-label">Where and how many people attended?</label>
+                <label class="col-sm-3 control-label">Where and how many people attended?</label>
                 <div class="col-sm-6">
                     <textarea class="form-control" name="past_attendance" rows="4">{{ app.past_attendance }}</textarea>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">&nbsp</label>
+                <label class="col-sm-3 control-label">&nbsp</label>
                 <div class="col-sm-6">
-                    <input type="checkbox" name='has_affiliations' {% if app.affiliations %}checked{% endif %} /> Do you have any group or website affiliations?
+                    <label class="checkbox-label" style="font-weight: normal;">
+                        <input type="checkbox" name='has_affiliations' {% if app.affiliations %}checked{% endif %} />
+                        Do you have any group or website affiliations?
+                    </label>
                 </div>
             </div>
             <div class="form-group" style="display:none">
-                <label class="col-sm-2 control-label">What are they?</label>
+                <label class="col-sm-3 control-label">What are they?</label>
                 <div class="col-sm-6">
                     <textarea class="form-control" name="affiliations" rows="4">{{ app.affiliations }}</textarea>
                 </div>
@@ -170,46 +183,54 @@
 
             <h3>Additional Information</h3>
             <div class="form-group" style="margin-bottom:0px">
-                <label class="col-sm-2 control-label">When are you unavailable?</label>
+                <label class="col-sm-3 control-label">When are you unavailable?</label>
                 <div class="col-sm-6">
                     <textarea class="form-control" name="unavailable" rows="4">{{ app.unavailable }}</textarea>
                 </div>
             </div>
             <div class="form-group">
-                <p class="help-block col-sm-6 col-sm-offset-2">
+                <p class="help-block col-sm-9 col-sm-offset-3">
                     Please list all times during the event when you will be UNAVAILABLE to hold your panel. <br/>
                     If we book you into a time slot, that is very difficult to change, so please be thorough.
                 </p>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">&nbsp</label>
-                <div class="col-sm-6">
-                    <input type="checkbox" name="verify_unavailable" {% if verify_unavailable %}checked{% endif %} />
-                    I verify I am available at any time during the event EXCEPT for the times listed above.
+                <label class="col-sm-3 control-label">&nbsp</label>
+                <div class="col-sm-9">
+                    <label class="checkbox-label" style="font-weight: normal;">
+                        <input type="checkbox" name="verify_unavailable" {% if verify_unavailable %}checked{% endif %} />
+                        I verify I am available at any time during the event EXCEPT for the times listed above.
+                    </label>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">&nbsp</label>
-                <div class="col-sm-6">
-                    <input type="checkbox" name="verify_waiting" {% if verify_waiting %}checked{% endif %} /> I understand that I will not hear back until {{ c.EXPECTED_RESPONSE }}, <b>and I will not prematurely e-mail {{ c.EVENT_NAME }} to check my panel status.</b>
+                <label class="col-sm-3 control-label">&nbsp</label>
+                <div class="col-sm-9 col-sm-offset-3">
+                    <label class="checkbox-label" style="font-weight: normal;">
+                        <input type="checkbox" name="verify_waiting" {% if verify_waiting %}checked{% endif %} />
+                        I understand that I will not hear back until {{ c.EXPECTED_RESPONSE }}, <b>and I will not prematurely email {{ c.EVENT_NAME }} to check my panel status.</b>
+                    </label>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">Please Describe:</label>
-                <div class="col-sm-6">
-                    <input type="input" class="form-control" name="other_presentation" value="{{ app.other_presentation }}" />
+                <label class="col-sm-3 control-label">Technical Needs</label>
+                <div class="col-sm-9">
+                    <p>
+                        Check the following technical needs that apply. Panel
+                        rooms will by default have VGA compatible projector
+                        with 3.5mm (1/8") audio, and a local PA with enough
+                        microphones setup.
+                    </p>
+                    <p>
+                        {{ macros.checkgroup(app, 'tech_needs') }}
+                    </p>
+                    <p>
+                      Other: <input type="text" name="other_tech_needs" value="{{ app.other_tech_needs }}" />
+                    </p>
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-2 control-label">Technical Needs</label>
-                <div class="col-sm-6">
-                    Check the following technical needs that apply. Panel rooms will by default have VGA compatible projector with 3.5mm (1/8") audio, and a local PA with enough microphones setup.
-                    {{ macros.checkgroup(app, 'tech_needs') }} <br/>
-                    Other: <input type="text" name="other_tech_needs" value="{{ app.other_tech_needs }}" />
-                </div>
-            </div>
-            <div class="form-group">
-                <label class="col-sm-2 control-label">What are you bringing?</label>
+                <label class="col-sm-3 control-label">What are you bringing?</label>
                 <div class="col-sm-6">
                     <input type="input" class="form-control" name="panelist_bringing" value="{{ app.panelist_bringing }}" placeholder="Windows laptop, Macbook, gaming console, etc" />
                 </div>
@@ -217,7 +238,7 @@
 
             <h3>Other Panelists</h3>
             <div class="form-group">
-                <label class="col-sm-2 control-label"></label>
+                <label class="col-sm-3 control-label"></label>
                 <div class="col-sm-6">
                     <select name="other_panelists">
                         {{ int_options(0, 9, ops_count) }}
@@ -246,30 +267,50 @@
                 </tbody>
             </table>
             <div id="point_of_contact" class="form-group" style="display:none">
-                <label class="col-sm-2 control-label">&nbsp;</label>
-                <div class="col-sm-6">
-                    I understand that by submitting this application, I am designating myself as the team leader and primary point of contact for this panel. I further understand that if I need to add or change panelists for this event I may be required to provide justification, and that this will be approved at the sole discretion of {{ c.EVENT_NAME }} Staff. <br/>
-                    <input type="checkbox" name="verify_poc" {% if verify_poc %}checked{% endif %} /> I have read and agree to the terms above.
+                <label class="col-sm-3 control-label">&nbsp;</label>
+                <p class="col-sm-9 col-sm-offset-3">
+                    I understand that by submitting this application, I am
+                    designating myself as the team leader and primary point of
+                    contact for this panel. I further understand that if I need
+                    to add or change panelists for this event I may be required
+                    to provide justification, and that this will be approved at
+                    the sole discretion of {{ c.EVENT_NAME }} Staff.
+                </p>
+                <div class="col-sm-9 col-sm-offset-3">
+                    <label class="checkbox-label" style="font-weight: normal;">
+                        <input type="checkbox" name="verify_poc" {% if verify_poc %}checked{% endif %} />
+                        I have read and agree to the terms above.
+                    </label>
                 </div>
             </div>
 
             <h3>Panelist Terms of Accomodation</h3>
             <div class="form-group">
-                <label class="col-sm-2 control-label">&nbsp;</label>
-                <div class="col-sm-6">
-                    "Panelists" at {{ c.EVENT_NAME }} receive free admission and the ability to present an awesome panel for like-minded people.  No travel, hotel, or other accommodations are provided by {{ c.EVENT_NAME }}.  If you have any questions, please contact <b>{{ c.PANELS_EMAIL }}</b>. <br/>
-                    <input type="checkbox" name="verify_tos" {% if verify_tos %}checked{% endif %} /> I have read and agree to the terms above.
+                <label class="col-sm-3 control-label">&nbsp;</label>
+                <p class="col-sm-9 col-sm-offset-3">
+                    "Panelists" at {{ c.EVENT_NAME }} receive free admission and
+                    the ability to present an awesome panel for like-minded
+                    people.  No travel, hotel, or other accommodations are
+                    provided by {{ c.EVENT_NAME }}.  If you have any questions,
+                    please contact <b>{{ c.PANELS_EMAIL }}</b>.
+                </p>
+                <div class="col-sm-9 col-sm-offset-3">
+                    <label class="checkbox-label" style="font-weight: normal;">
+                        <input type="checkbox" name="verify_tos" {% if verify_tos %}checked{% endif %} />
+                        I have read and agree to the terms above.
+                    </label>
                 </div>
             </div>
 
             <div class="form-group">
-                <div class="col-sm-6 col-sm-offset-2">
+                <div class="col-sm-6 col-sm-offset-3">
                     <button type="submit" class="btn btn-primary">Submit Application</button>
                 </div>
             </div>
 
         </form>
     {% endif %}
+  </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Fixes magfest/ubersystem/issues/2683
Fixes magfest/ubersystem/issues/2684

Admins can now move a panels application from the cancelled
state back to accepted, waitlisted, or declined. Also changes
the cancel wording from "Cancel Application" to "Cancel Panel",
per #2683.