### PR TITLE
Convert to using a MultiChoice column for ribbons

### DIFF
--- a/panels/site_sections/panel_app_management.py
+++ b/panels/site_sections/panel_app_management.py
@@ -110,8 +110,8 @@ class Root:
         ids = []
         try:
             attendee = session.attendee(attendee_id)
-            if attendee.ribbon == c.NO_RIBBON and attendee.badge_type != c.GUEST_BADGE:
-                attendee.ribbon = c.PANELIST_RIBBON
+            if attendee.badge_type != c.GUEST_BADGE:
+                attendee.ribbon = add_opt(attendee.ribbon_ints, c.PANELIST_RIBBON)
 
             pa = session.panel_applicant(applicant_id)
             for applicant in session.query(PanelApplicant).filter_by(first_name=pa.first_name, last_name=pa.last_name, email=pa.email):

--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -192,7 +192,7 @@ class Root:
             'assigned': [ap.attendee_id for ap in sorted(event.assigned_panelists, reverse=True, key=lambda a: a.attendee.first_name)],
             'panelists': [(a.id, a.full_name)
                           for a in session.query(Attendee)
-                                          .filter(or_(Attendee.ribbon == c.PANELIST_RIBBON,
+                                          .filter(or_(Attendee.ribbon.contains(c.PANELIST_RIBBON),
                                                       Attendee.badge_type == c.GUEST_BADGE))
                                           .order_by(Attendee.full_name).all()]
         }

--- a/panels/templates/panel_app_management/mark.html
+++ b/panels/templates/panel_app_management/mark.html
@@ -22,10 +22,8 @@ Submitting this form will mark this application as {{ app.status_label|lower }} 
                         They will be automatically added to the group created for this panel.
                     {% endif %}
                 {% endif %}
-                {% if applicant.matching_attendee.ribbon == c.NO_RIBBON %}
+                {% if c.PANELIST_RIBBON not in applicant.matching_attendee.ribbon_ints %}
                     They will be assigned a panelist ribbon.
-                {% else %}
-                    Because they already have a {{ applicant.matching_attendee.ribbon_label }} ribbon, no Panelist ribbon will be assigned.
                 {% endif %}
             {% else %}
                 {{ applicant.full_name }} will be added with a complementary Attendee badge with a Panelist ribbon{% if group %} to the group for this panel{% endif %}.


### PR DESCRIPTION
Must be merged after https://github.com/magfest/ubersystem/pull/2711. Converts this plugin to using the syntax needed for the new MultiChoice ribbons.