### PR TITLE
Improve data migration for panels to fix length display

### DIFF
--- a/alembic/versions/3733faf640e9_add_additional_fields_to_panel_app.py
+++ b/alembic/versions/3733faf640e9_add_additional_fields_to_panel_app.py
@@ -34,7 +34,8 @@ panel_app_helper = table(
         'panel_application',
         sa.Column('id', sideboard.lib.sa.UUID(), nullable=False),
         sa.Column('length', sa.Unicode()),
-        sa.Column('length_text', sa.Unicode())
+        sa.Column('length_text', sa.Unicode()),
+        sa.Column('length_reason', sa.Unicode())
         # Other columns not needed
     )
 
@@ -52,12 +53,14 @@ def upgrade():
     connection = op.get_bind()
 
     for panel_app in connection.execute(panel_app_helper.select()):
-        length_text = panel_app.length
+        new_length_text = panel_app.length
         connection.execute(
             panel_app_helper.update().where(
                 panel_app_helper.c.id == panel_app.id
             ).values(
-                length_text=length_text
+                length_text=new_length_text,
+                length=c.OTHER,
+                length_reason="Automated data migration."
             )
         )
 

--- a/panels/templates/panel_app_management/app.html
+++ b/panels/templates/panel_app_management/app.html
@@ -108,7 +108,7 @@
     <div class="form-group">
         <label class="col-sm-3 control-label">Expected Length</label>
         <div class="col-sm-6 form-control-static">
-            {{ app.length_label if app.length != c.OTHER else app.length_text }}
+            {{ app.length_label if app.length != c.OTHER and not app.length_text else app.length_text }}
         </div>
     </div>
 


### PR DESCRIPTION
We also now display the panel length_text as long as it exists.