### PR TITLE
Removes csrf checks from panel submissions.

### DIFF
--- a/panels/site_sections/panel_applications.py
+++ b/panels/site_sections/panel_applications.py
@@ -18,8 +18,8 @@ class Root:
         must POST to a different URL in order to bypass the cache and get a
         valid session cookie. Thus, this page is also exposed as "post_index".
         """
-        app = session.panel_application(params, checkgroups={'tech_needs'}, restricted=True)
-        panelist = session.panel_applicant(params, restricted=True)
+        app = session.panel_application(params, checkgroups={'tech_needs'}, restricted=True, ignore_csrf=True)
+        panelist = session.panel_applicant(params, restricted=True, ignore_csrf=True)
         panelist.application = app
         other_panelists = []
         for i in range(int(params.get('other_panelists', 0))):

--- a/panels/templates/panel_applications/index.html
+++ b/panels/templates/panel_applications/index.html
@@ -59,7 +59,6 @@
 
         {# The action is set to "post_index" in order to bypass the NGINX cache. -#}
         <form method="post" action="post_index" class="form-horizontal" role="form">
-            {{ csrf_token() }}
             <input type="hidden" name="submitter" value="1" />
 
             <h3>Personal Information</h3>


### PR DESCRIPTION
/panel_applications/index is now cached via nginx, so we can't dynamically generate a csrf token for the page. Fortunately we don't need to check for it in this case, because that page doesn't have any exploitable csrf vulnerabilities.