### PR TITLE
Fix timespan printed in emails to panelists

### DIFF
--- a/panels/templates/emails/panel_app_scheduled.txt
+++ b/panels/templates/emails/panel_app_scheduled.txt
@@ -1,6 +1,6 @@
 {{ app.submitter.first_name }},
 
-"{{ app.name }}", the panel you submitted for {{ c.EVENT_NAME }}, has been scheduled.  {{ c.EVENT_NAME }} is {{ c.EPOCH|datetime_local("%A, %B %-d") }} through {{ c.ESCHATON|datetime_local("%A, %B %-d") }}, and your panel is currently scheduled for {{ app.event.timespan() }}.  This scheduling can be changed if absolutely necessary, but it was chosen based on your and others' declared availability.
+"{{ app.name }}", the panel you submitted for {{ c.EVENT_NAME }}, has been scheduled.  {{ c.EVENT_NAME }} is {{ c.EPOCH|datetime_local("%A, %B %-d") }} through {{ c.ESCHATON|datetime_local("%A, %B %-d") }}, and your panel is currently scheduled for {{ app.event.timespan(minute_increment=30) }}.  This scheduling can be changed if absolutely necessary, but it was chosen based on your and others' declared availability.
 
 If you have any questions or concerns, please don't hesitate to send them to {{ c.PANELS_EMAIL|email_only }}.
 

--- a/panels/templates/panel_app_management/associate.html
+++ b/panels/templates/panel_app_management/associate.html
@@ -54,7 +54,7 @@ Use the form below to associate this application with an event on the schedule. 
     <select name="event_id">
         <option value="">Select an event</option>
         {% for event in panels %}
-            <option value="{{ event.id }}">{{ event.name }} [{{ event.location_label }}] ({{ event.timespan() }})</option>
+            <option value="{{ event.id }}">{{ event.name }} [{{ event.location_label }}] ({{ event.timespan(minute_increment=30) }})</option>
         {% endfor %}
     </select>
     <input type="submit" value="Associate" />


### PR DESCRIPTION
Panelists were being told that their panels would last twice as long as they actually will. This fixes that by specifying that the event length is counted in half-hour increments, not hour-increments like the timespan() function expects.