### PR TITLE
Fixes ability to uncheck checkgroups on various panel forms

### DIFF
--- a/panels/site_sections/panel_app_management.py
+++ b/panels/site_sections/panel_app_management.py
@@ -16,7 +16,7 @@ class Root:
         }
 
     def form(self, session, message='', **params):
-        app = session.panel_application(params)
+        app = session.panel_application(params, checkgroups=PanelApplication.all_checkgroups)
         if cherrypy.request.method == 'POST':
             message = check(app)
             if not message:
@@ -58,7 +58,7 @@ class Root:
 
     def edit_panelist(self, session, **params):
         is_post = cherrypy.request.method == 'POST'
-        panelist = session.panel_applicant(params, ignore_csrf=not is_post)
+        panelist = session.panel_applicant(params, checkgroups=PanelApplicant.all_checkgroups, ignore_csrf=not is_post)
         application = session.query(PanelApplication).get(params.get('app_id', panelist.app_id))
         if is_post:
             message = check(panelist)

--- a/panels/site_sections/panel_applications.py
+++ b/panels/site_sections/panel_applications.py
@@ -27,9 +27,9 @@ class Root:
         must POST to a different URL in order to bypass the cache and get a
         valid session cookie. Thus, this page is also exposed as "post_index".
         """
-        app = session.panel_application(params, checkgroups={'tech_needs'}, restricted=True, ignore_csrf=True)
+        app = session.panel_application(params, checkgroups=PanelApplication.all_checkgroups, restricted=True, ignore_csrf=True)
         panelist_params = {attr: params.get('{}_0'.format(attr)) for attr in PANELISTS_FIELDS if params.get('{}_0'.format(attr))}
-        panelist = session.panel_applicant(panelist_params, restricted=True, ignore_csrf=True)
+        panelist = session.panel_applicant(panelist_params, checkgroups=PanelApplicant.all_checkgroups, restricted=True, ignore_csrf=True)
         panelist.application = app
         panelist.submitter = True
         other_panelists = []

--- a/panels/templates/panel_app_management/edit_panelist.html
+++ b/panels/templates/panel_app_management/edit_panelist.html
@@ -25,7 +25,7 @@
 
   <div class="form-group">
     <div class="col-sm-6 col-sm-offset-3">
-      <button type="submit" class="btn btn-primary">Submit</button>
+      <button type="submit" class="btn btn-primary">Save</button>
     </div>
   </div>
 </form>


### PR DESCRIPTION
As it stands, you if any items in a check group are selected, you can't go back and uncheck them. So, if I create a panel application with "Projector" selected for "Technical Needs", and can't go back and edit that application and remove "Projector".

This pull request fixes that.