### PR TITLE
Add panel application for pre-approved panelists

### DIFF
--- a/panels/configspec.ini
+++ b/panels/configspec.ini
@@ -25,7 +25,7 @@ social_media = string_list(default=list("Facebook", "Twitter", "Instagram", "Lin
 # How many applications someone can submit as a confirmed PoC.
 # This limits how many applications someone can submit via the guest form.
 # Set this to 0 to remove limits from guest panel applications.
-app_limit = integer(default=0)
+app_limit = integer(default=3)
 
 # These are used as templates to generate social media links, in case a
 # panelist provides a username instead of a direct link to their social media

--- a/panels/configspec.ini
+++ b/panels/configspec.ini
@@ -22,6 +22,11 @@ panels_email_signature = string(default=" - MAGFest Panels Team")
 # under_scored) and added as attributes on the PanelApplicant class.
 social_media = string_list(default=list("Facebook", "Twitter", "Instagram", "LinkedIn"))
 
+# How many applications someone can submit as a confirmed PoC.
+# This limits how many applications someone can submit via the guest form.
+# Set this to 0 to remove limits from guest panel applications.
+app_limit = integer(default=0)
+
 # These are used as templates to generate social media links, in case a
 # panelist provides a username instead of a direct link to their social media
 # page. The keys should match "fieldified" values in the "social_media" list.
@@ -82,6 +87,7 @@ custom_av = string(default="Custom A/V Setup")
 
 [[presentation]]
 qa = string(default="Mostly just Question and Answer")
+group_discussion = string(default="Group Discussion with Moderator")
 basic = string(default="Basic presentation with some Q&A")
 advanced_av = string(default="Presentation requiring advanced A/V")
 workshop = string(default="Workshop or Tech/Interactive Demo")

--- a/panels/site_sections/panel_applications.py
+++ b/panels/site_sections/panel_applications.py
@@ -61,7 +61,7 @@ class Root:
             if not message:
                 message = process_panel_app(session, app, panelist, **params)
                 if not message:
-                    raise HTTPRedirect('guest?poc_id={}message={}', poc_id, 'Your panel application has been submitted')
+                    raise HTTPRedirect('index?message={}', 'Your panel application has been submitted')
 
         return {
             'app': app,

--- a/panels/site_sections/panel_applications.py
+++ b/panels/site_sections/panel_applications.py
@@ -17,6 +17,29 @@ def check_other_panelists(other_panelists):
             return '{} (for Other Panelist #{})'.format(message, i + 1)
 
 
+def check_extra_verifications(other_panelists=False, **params):
+    """
+    Panelists submitting an application not associated with an attendee have some extra checkboxes they have
+    to tick, so we validate them all here.
+    """
+    if 'verify_waiting' not in params:
+        return 'You must check the box to verify you understand that you will not hear back until {}'.format(
+            c.EXPECTED_RESPONSE)
+    elif 'verify_tos' not in params:
+        return 'You must accept our Terms of Accommodation'
+    elif other_panelists and 'verify_poc' not in params:
+        return 'You must agree to being the point of contact for your group'
+
+
+def other_panelists_from_params(app, **params):
+    # Turns form fields into a list of dicts of extra panelists on a panel application.
+    other_panelists = []
+    for i in range(1, int(params.get('other_panelists', 0)) + 1):
+        applicant = {attr: params.get('{}_{}'.format(attr, i)) for attr in OTHER_PANELISTS_FIELDS}
+        other_panelists.append(PanelApplicant(application=app, **applicant))
+    return other_panelists
+
+
 @all_renderable()
 class Root:
     @cherrypy.expose(['post_index'])
@@ -32,34 +55,72 @@ class Root:
         panelist = session.panel_applicant(panelist_params, checkgroups=PanelApplicant.all_checkgroups, restricted=True, ignore_csrf=True)
         panelist.application = app
         panelist.submitter = True
-        other_panelists = []
-        for i in range(1, int(params.get('other_panelists', 0)) + 1):
-            applicant = {attr: params.get('{}_{}'.format(attr, i)) for attr in OTHER_PANELISTS_FIELDS}
-            other_panelists.append(PanelApplicant(application=app, **applicant))
 
         if cherrypy.request.method == 'POST':
-            message = check(panelist) or check(app) or check_other_panelists(other_panelists)
+            message = check(panelist) or check_extra_verifications(int(params.get('other_panelists', 0)), **params)
             if not message:
-                if 'verify_unavailable' not in params:
-                    message = 'You must check the box to confirm that you are only unavailable at the specified times'
-                elif 'verify_waiting' not in params:
-                    message = 'You must check the box to verify you understand that you will not hear back until {}'.format(c.EXPECTED_RESPONSE)
-                elif 'verify_tos' not in params:
-                    message = 'You must accept our Terms of Accomodation'
-                elif other_panelists and 'verify_poc' not in params:
-                    message = 'You must agree to being the point of contact for your group'
-                else:
-                    session.add_all([app, panelist] + other_panelists)
-                    raise HTTPRedirect('index?message={}', 'Your panel application has been submitted')
+                message = process_panel_app(session, app, panelist, **params)
+                if not message:
+                    raise HTTPRedirect('guest?poc_id={}message={}', poc_id, 'Your panel application has been submitted')
 
         return {
             'app': app,
             'message': message,
             'panelist': panelist,
-            'ops_count': len(other_panelists),
-            'other_panelists': other_panelists,
+            'other_panelists': other_panelists_from_params(app, **params),
             'verify_tos': params.get('verify_tos'),
-            'verify_poc': params.get('verify_pos'),
+            'verify_poc': params.get('verify_poc'),
             'verify_waiting': params.get('verify_waiting'),
             'verify_unavailable': params.get('verify_unavailable')
         }
+
+    def guest(self, session, poc_id, message='', **params):
+        """
+        In some cases, we want pre-existing attendees (e.g., guests) to submit panel ideas.
+        This submission form bypasses the need to enter in one's personal and contact info
+        in favor of having the panel application automatically associated with an attendee
+        record, both as the submitter and as the Point of Contact.
+        """
+
+        app = session.panel_application(params, checkgroups=PanelApplication.all_checkgroups, restricted=True, ignore_csrf=True)
+        app.poc_id = poc_id
+        attendee = session.attendee(id=poc_id)
+        panelist = PanelApplicant(
+            app_id=app.id,
+            attendee_id=attendee.id,
+            submitter=True,
+            first_name=attendee.first_name,
+            last_name=attendee.last_name,
+            email=attendee.email,
+            cellphone=attendee.cellphone
+        )
+
+        if cherrypy.request.method == 'POST':
+            message = process_panel_app(session, app, panelist, **params)
+            if not message:
+                raise HTTPRedirect('guest?poc_id={}&message={}', poc_id, 'Your panel application has been submitted')
+
+        return {
+            'app': app,
+            'message': message,
+            'attendee': attendee,
+            'poc_id': poc_id,
+            'other_panelists': other_panelists_from_params(app, **params),
+            'verify_unavailable': params.get('verify_unavailable')
+        }
+
+
+def process_panel_app(session, app, panelist, **params):
+    """
+    Checks various parts of a new panel application, either submitted by guests or by non-attendees,
+    and then adds them to a session.
+    """
+    other_panelists = other_panelists_from_params(app, **params)
+
+    message = check(app) or check_other_panelists(other_panelists) or ''
+    if not message and 'verify_unavailable' not in params:
+        message = 'You must check the box to confirm that you are only unavailable at the specified times'
+    elif not message:
+        session.add_all([app, panelist] + other_panelists)
+
+    return message

--- a/panels/templates/other_panelists_form.html
+++ b/panels/templates/other_panelists_form.html
@@ -52,7 +52,7 @@
         <h2>Other Panelist #{{ loop.index }}</h2>
         {{ panel_macros.panelist_form(
             op,
-            suffix='_' + loop.index0|string,
+            suffix='_' + loop.index1|string,
             include_cellphone=False,
             include_communication_pref=False) }}
       </div>

--- a/panels/templates/other_panelists_form.html
+++ b/panels/templates/other_panelists_form.html
@@ -21,8 +21,20 @@
     $(function () {
         showOrHideOtherPanelists();
         $.field('other_panelists').on('change', showOrHideOtherPanelists);
+
+        // Move the template out of the <form> tag to avoid validation errors
+        $('#panelist_form_template').appendTo($('body'));
     });
 </script>
+
+<div id="panelist_form_template" style="display: none;">
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <h2>Other Panelist #</h2>
+      {{ panel_macros.panelist_form(PanelApplicant, require_cellphone=False, require_communication_pref=False) }}
+    </div>
+  </div>
+</div>
 
 <div class="form-group">
   <div class="col-sm-6 col-sm-offset-3">

--- a/panels/templates/other_panelists_form.html
+++ b/panels/templates/other_panelists_form.html
@@ -1,0 +1,49 @@
+<script type="text/javascript">
+    var showOrHideOtherPanelists = function () {
+        var count = $.val('other_panelists'),
+            $template = $('#panelist_form_template > .panel'),
+            $ops = $('#panelists_container > .panel');
+        setVisible('#panelists_container', count);
+        if (count < $ops.size()) {
+            $ops.slice(count).remove();
+        } else {
+            for (var i = $ops.size() + 1; i <= count; i++) {
+                var suffix = '_' + i;
+                var $opPanel = $template.clone();
+                $opPanel.find('h2').text($opPanel.find('h2').text() + i);
+                $opPanel.find('input').attr('name', function() { return $(this).attr('name') + suffix } );
+                $opPanel.find('textarea').attr('name', function() { return $(this).attr('name') + suffix } );
+                $opPanel.appendTo('#panelists_container');
+            }
+        }
+    };
+
+    $(function () {
+        showOrHideOtherPanelists();
+        $.field('other_panelists').on('change', showOrHideOtherPanelists);
+    });
+</script>
+
+<div class="form-group">
+  <div class="col-sm-6 col-sm-offset-3">
+    <select name="other_panelists">
+      {{ int_options(0, 9, other_panelists|length) }}
+    </select>
+    How many other panelists will be on this panel?
+  </div>
+</div>
+
+<div id="panelists_container">
+  {% for op in other_panelists %}
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <h2>Other Panelist #{{ loop.index }}</h2>
+        {{ panel_macros.panelist_form(
+            op,
+            suffix='_' + loop.index0|string,
+            include_cellphone=False,
+            include_communication_pref=False) }}
+      </div>
+    </div>
+  {% endfor %}
+</div>

--- a/panels/templates/panel_app_form.html
+++ b/panels/templates/panel_app_form.html
@@ -15,11 +15,16 @@
         setVisible($.field('length_reason').parents('.form-group'), isNotAnHour);
         $.field('length_reason').prop('required', isNotAnHour);
     };
+    var showOrHideModHelp = function() {
+        setVisible($('#mod_help'), $.val('presentation') === {{ c.GROUP_DISCUSSION }})
+    };
 
     $(function () {
         showOrHideOtherPresentation();
         showOrHideOtherLength();
+        showOrHideModHelp();
         $.field('presentation').on('change', showOrHideOtherPresentation);
+        $.field('presentation').on('change', showOrHideModHelp);
         $.field('length').on('change', showOrHideOtherLength);
     });
 </script>
@@ -40,6 +45,11 @@
     <div class="col-sm-6 col-sm-offset-3" style="margin-top: 15px;">
         <input type="input" class="form-control" name="other_presentation" value="{{ app.other_presentation }}" placeholder="Please describe type of panel" />
     </div>
+    <div class="clearfix"></div>
+    <p class="help-block col-sm-9 col-sm-offset-3" id="mod_help">
+      Please include who will moderate the panel in the description. If you will not be moderating the panel, please add
+      the moderator as a panelist at the bottom of this application.
+    </p>
 </div>
 <div class="form-group">
     <label class="col-sm-3 control-label">Panel Description</label>

--- a/panels/templates/panel_applications/guest.html
+++ b/panels/templates/panel_applications/guest.html
@@ -5,15 +5,6 @@
 {% block content %}
   {% include "panels_common.html" %}
 
-  {# This needs to be placed outside the <form> tag or we get validation errors #}
-  <div id="panelist_form_template" style="display: none;">
-    <div class="panel panel-default">
-      <div class="panel-body">
-        <h2>Other Panelist #</h2>
-        {{ panel_macros.panelist_form(PanelApplicant, require_cellphone=False, require_communication_pref=False) }}
-      </div>
-    </div>
-  </div>
 
   <div class="masthead"></div>
   <div class="panel panel-default">

--- a/panels/templates/panel_applications/guest.html
+++ b/panels/templates/panel_applications/guest.html
@@ -1,0 +1,81 @@
+{% extends "preregistration/preregbase.html" %}
+{% import 'panel_macros.html' as panel_macros %}
+{% block title %}Panel Application{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+  {% include "panels_common.html" %}
+
+  {# This needs to be placed outside the <form> tag or we get validation errors #}
+  <div id="panelist_form_template" style="display: none;">
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <h2>Other Panelist #</h2>
+        {{ panel_macros.panelist_form(PanelApplicant, require_cellphone=False, require_communication_pref=False) }}
+      </div>
+    </div>
+  </div>
+
+  <div class="masthead"></div>
+  <div class="panel panel-default">
+    <div class="panel-body">
+    {% if c.APP_LIMIT and attendee.panel_applications|length >= c.APP_LIMIT %}
+      You have already submitted the maximum number of panels ({{ c.APP_LIMIT }}). Please contact your liaison if
+      you need to change a panel or submit more ideas.
+    {% else %}
+      {% if c.APP_LIMIT %}
+        You may submit up to {{ c.APP_LIMIT }} panel ideas.
+        {% if attendee.panel_applications %}
+          You have already submitted {{ attendee.panel_applications|length }}.
+        {% endif %}
+      {% endif %}
+      <form method="post" action="guest" class="form-horizontal" role="form">
+
+      <input type="hidden" name="poc_id" value="{{ poc_id }}" />
+
+      <h3>Panel Information</h3>
+      {% include "panel_app_form.html" %}
+
+      <h3>Additional Information</h3>
+      <div class="form-group">
+        <label class="col-sm-3 control-label">When are you unavailable?</label>
+        <div class="col-sm-6">
+          <textarea class="form-control" name="unavailable" rows="4" required="required">{{ app.unavailable }}</textarea>
+        </div>
+        <div class="clearfix"></div>
+        <p class="help-block col-sm-9 col-sm-offset-3">
+          Please list all times during the event when you will be UNAVAILABLE to hold your panel.
+          If we book you into a time slot, that is very difficult to change, so please be thorough.
+        </p>
+      </div>
+      <div class="form-group">
+        <div class="col-sm-9 col-sm-offset-3">
+          <label class="checkbox-label" style="font-weight: normal;">
+            <input type="checkbox" name="verify_unavailable" {% if verify_unavailable %}checked{% endif %} />
+            I verify I am available at any time during the event EXCEPT for the times listed above.
+          </label>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="col-sm-3 control-label">What else might we need to know?</label>
+        <div class="col-sm-6">
+          <textarea class="form-control" name="extra_info" rows="4">{{ app.extra_info }}</textarea>
+        </div>
+        <div class="clearfix"></div>
+        <p class="help-block col-sm-9 col-sm-offset-3">
+          This can include information not for public consumption, but merely things the event needs to know.
+        </p>
+      </div>
+
+      <h3>Other Panelists</h3>
+      {% include "other_panelists_form.html" %}
+
+      <div class="form-group">
+        <div class="col-sm-6 col-sm-offset-3">
+          <button type="submit" class="btn btn-primary">Submit Panel Idea</button>
+        </div>
+      </div>
+      </form>
+    {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/panels/templates/panel_applications/index.html
+++ b/panels/templates/panel_applications/index.html
@@ -3,44 +3,34 @@
 {% block title %}Panel Applications{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-{% include "panels_common.html" %}
+  {% include "panels_common.html" %}
 
-<script type="text/javascript">
-    var showOrHidePOC = function () {
-        setVisible('#point_of_contact', $.val('other_panelists'));
-    };
+  <script type="text/javascript">
+      var showOrHidePOC = function () {
+          setVisible('#point_of_contact', $.val('other_panelists'));
+      };
 
-    $(function () {
-        $('<br/>').insertBefore('nobr');
-        showOrHidePOC();
-        $.field('other_panelists').on('change', showOrHidePOC);
-    });
-</script>
+      $(function () {
+          $('<br/>').insertBefore('nobr');
+          showOrHidePOC();
+          $.field('other_panelists').on('change', showOrHidePOC);
+      });
+  </script>
 
-{# This needs to be placed outside the <form> tag or we get validation errors #}
-<div id="panelist_form_template" style="display: none;">
+  <div class="masthead"></div>
   <div class="panel panel-default">
     <div class="panel-body">
-      <h2>Other Panelist #</h2>
-      {{ panel_macros.panelist_form(PanelApplicant, require_cellphone=False, require_communication_pref=False) }}
-    </div>
-  </div>
-</div>
+      <h2>{{ c.EVENT_NAME }} Panel Submission Form</h2>
 
-<div class="masthead"></div>
-<div class="panel panel-default">
-    <div class="panel-body">
-    <h2>{{ c.EVENT_NAME }} Panel Submission Form</h2>
-
-    {% if c.AFTER_PANEL_APP_DEADLINE and not c.HAS_PANEL_APPS_ACCESS %}
+      {% if c.AFTER_PANEL_APP_DEADLINE and not c.HAS_PANEL_APPS_ACCESS %}
         Unfortunately, the deadline for panel applications has passed and we are no longer accepting panel submissions.
-    {% else %}
+      {% else %}
         {% if c.AFTER_PANEL_APP_DEADLINE and c.HAS_PANEL_APPS_ACCESS %}
-            <span style="color:red">
-                Panel applications have closed, but because you are a logged in
-                administrator you can submit a new application using this form.
-            </span>
-            <br/> <br/>
+          <span style="color:red">
+            Panel applications have closed, but because you are a logged in
+            administrator you can submit a new application using this form.
+          </span>
+          <br/> <br/>
         {% endif %}
         We expect many requests being sent in and will be unable to accept them
         all. To increase your odds of acceptance, fill this form out
@@ -57,16 +47,16 @@
 
         {# The action is set to "post_index" in order to bypass the NGINX cache. -#}
         <form method="post" action="post_index" class="form-horizontal" role="form">
-            {{ panel_macros.panelist_form(panelist, suffix='_0') }}
+          {{ panel_macros.panelist_form(panelist, suffix='_0') }}
 
-            <h3>Panel Information</h3>
-            {% include "panel_app_form.html" %}
+          <h3>Panel Information</h3>
+          {% include "panel_app_form.html" %}
 
-            <h3>Additional Information</h3>
+          <h3>Additional Information</h3>
 
-            <div class="form-group">
-                <div class="col-sm-9 col-sm-offset-3 checkbox">
-                    {{ macros.toggle_checkbox(
+          <div class="form-group">
+            <div class="col-sm-9 col-sm-offset-3 checkbox">
+              {{ macros.toggle_checkbox(
                         '.form-group-past_attendance',
                         'Have you held this panel before?',
                         suffix='_past_attendance',
@@ -74,18 +64,18 @@
                         required_selector='.form-group-past_attendance .form-control',
                         hide_on_checked=False,
                         checked=app.past_attendance) }}
-                </div>
             </div>
-            <div class="form-group form-group-past_attendance">
-                <label class="col-sm-3 control-label">Where and how many people attended?</label>
-                <div class="col-sm-6">
-                    <textarea class="form-control" name="past_attendance" rows="4">{{ app.past_attendance }}</textarea>
-                </div>
+          </div>
+          <div class="form-group form-group-past_attendance">
+            <label class="col-sm-3 control-label">Where and how many people attended?</label>
+            <div class="col-sm-6">
+              <textarea class="form-control" name="past_attendance" rows="4">{{ app.past_attendance }}</textarea>
             </div>
+          </div>
 
-            <div class="form-group">
-                <div class="col-sm-9 col-sm-offset-3 checkbox">
-                    {{ macros.toggle_checkbox(
+          <div class="form-group">
+            <div class="col-sm-9 col-sm-offset-3 checkbox">
+              {{ macros.toggle_checkbox(
                         '.form-group-affiliations',
                         'Do you have any group or website affiliations?',
                         suffix='_affiliations',
@@ -93,100 +83,100 @@
                         required_selector='.form-group-affiliations .form-control',
                         hide_on_checked=False,
                         checked=app.affiliations) }}
-                </div>
             </div>
-            <div class="form-group form-group-affiliations">
-                <label class="col-sm-3 control-label">What are they?</label>
-                <div class="col-sm-6">
-                    <textarea class="form-control" name="affiliations" rows="4">{{ app.affiliations }}</textarea>
-                </div>
+          </div>
+          <div class="form-group form-group-affiliations">
+            <label class="col-sm-3 control-label">What are they?</label>
+            <div class="col-sm-6">
+              <textarea class="form-control" name="affiliations" rows="4">{{ app.affiliations }}</textarea>
             </div>
+          </div>
 
-            <div class="form-group">
-                <label class="col-sm-3 control-label">When are you unavailable?</label>
-                <div class="col-sm-6">
-                    <textarea class="form-control" name="unavailable" rows="4" required="required">{{ app.unavailable }}</textarea>
-                </div>
-                <div class="clearfix"></div>
-                <p class="help-block col-sm-9 col-sm-offset-3">
-                    Please list all times during the event when you will be UNAVAILABLE to hold your panel.
-                    If we book you into a time slot, that is very difficult to change, so please be thorough.
-                </p>
+          <div class="form-group">
+            <label class="col-sm-3 control-label">When are you unavailable?</label>
+            <div class="col-sm-6">
+              <textarea class="form-control" name="unavailable" rows="4" required="required">{{ app.unavailable }}</textarea>
             </div>
-            <div class="form-group">
-                <div class="col-sm-9 col-sm-offset-3">
-                    <label class="checkbox-label" style="font-weight: normal;">
-                        <input type="checkbox" name="verify_unavailable" {% if verify_unavailable %}checked{% endif %} />
-                        I verify I am available at any time during the event EXCEPT for the times listed above.
-                    </label>
-                </div>
+            <div class="clearfix"></div>
+            <p class="help-block col-sm-9 col-sm-offset-3">
+              Please list all times during the event when you will be UNAVAILABLE to hold your panel.
+              If we book you into a time slot, that is very difficult to change, so please be thorough.
+            </p>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-9 col-sm-offset-3">
+              <label class="checkbox-label" style="font-weight: normal;">
+                <input type="checkbox" name="verify_unavailable" {% if verify_unavailable %}checked{% endif %} />
+                I verify I am available at any time during the event EXCEPT for the times listed above.
+              </label>
             </div>
-            <div class="form-group">
-                <label class="col-sm-3 control-label">What else might we need to know?</label>
-                <div class="col-sm-6">
-                    <textarea class="form-control" name="extra_info" rows="4">{{ app.extra_info }}</textarea>
-                </div>
-                <div class="clearfix"></div>
-                <p class="help-block col-sm-9 col-sm-offset-3">
-                    This can include information not for public consumption, but merely things the event needs to know.
-                </p>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-3 control-label">What else might we need to know?</label>
+            <div class="col-sm-6">
+              <textarea class="form-control" name="extra_info" rows="4">{{ app.extra_info }}</textarea>
             </div>
-            <div class="form-group">
-                <div class="col-sm-9 col-sm-offset-3">
-                    <label class="checkbox-label" style="font-weight: normal;">
-                        <input type="checkbox" name="verify_waiting" {% if verify_waiting %}checked{% endif %} />
-                        I understand that I will not hear back until {{ c.EXPECTED_RESPONSE }},
-                        <b>and I will not prematurely email {{ c.EVENT_NAME }} to check my panel status.</b>
-                    </label>
-                </div>
+            <div class="clearfix"></div>
+            <p class="help-block col-sm-9 col-sm-offset-3">
+              This can include information not for public consumption, but merely things the event needs to know.
+            </p>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-9 col-sm-offset-3">
+              <label class="checkbox-label" style="font-weight: normal;">
+                <input type="checkbox" name="verify_waiting" {% if verify_waiting %}checked{% endif %} />
+                I understand that I will not hear back until {{ c.EXPECTED_RESPONSE }},
+                <b>and I will not prematurely email {{ c.EVENT_NAME }} to check my panel status.</b>
+              </label>
             </div>
+          </div>
 
-            <h3>Other Panelists</h3>
-            {% include "other_panelists_form.html" %}
+          <h3>Other Panelists</h3>
+          {% include "other_panelists_form.html" %}
 
-            <div id="point_of_contact" class="form-group" style="display:none">
-                <p class="col-sm-9 col-sm-offset-3">
-                    I understand that by submitting this application, I am
-                    designating myself as the team leader and primary point of
-                    contact for this panel. I further understand that if I need
-                    to add or change panelists for this event I may be required
-                    to provide justification, and that this will be approved at
-                    the sole discretion of {{ c.EVENT_NAME }} Staff.
-                </p>
-                <div class="col-sm-9 col-sm-offset-3">
-                    <label class="checkbox-label" style="font-weight: normal;">
-                        <input type="checkbox" name="verify_poc" {% if verify_poc %}checked{% endif %} />
-                        I have read and agree to the terms above.
-                    </label>
-                </div>
+          <div id="point_of_contact" class="form-group" style="display:none">
+            <p class="col-sm-9 col-sm-offset-3">
+              I understand that by submitting this application, I am
+              designating myself as the team leader and primary point of
+              contact for this panel. I further understand that if I need
+              to add or change panelists for this event I may be required
+              to provide justification, and that this will be approved at
+              the sole discretion of {{ c.EVENT_NAME }} Staff.
+            </p>
+            <div class="col-sm-9 col-sm-offset-3">
+              <label class="checkbox-label" style="font-weight: normal;">
+                <input type="checkbox" name="verify_poc" {% if verify_poc %}checked{% endif %} />
+                I have read and agree to the terms above.
+              </label>
             </div>
+          </div>
 
-            <h3>Panelist Terms of Accommodation</h3>
-            <div class="form-group">
-                <p class="col-sm-9 col-sm-offset-3">
-                    "Panelists" at {{ c.EVENT_NAME }} receive free admission and
-                    the ability to present an awesome panel for like-minded
-                    people.  No travel, hotel, or other accommodations are
-                    provided by {{ c.EVENT_NAME }}.  If you have any questions,
-                    please contact <b>{{ c.PANELS_EMAIL }}</b>.
-                </p>
-                <div class="col-sm-9 col-sm-offset-3">
-                    <label class="checkbox-label" style="font-weight: normal;">
-                        <input type="checkbox" name="verify_tos" {% if verify_tos %}checked{% endif %} />
-                        I have read and agree to the terms above.
-                    </label>
-                </div>
+          <h3>Panelist Terms of Accommodation</h3>
+          <div class="form-group">
+            <p class="col-sm-9 col-sm-offset-3">
+              "Panelists" at {{ c.EVENT_NAME }} receive free admission and
+              the ability to present an awesome panel for like-minded
+              people.  No travel, hotel, or other accommodations are
+              provided by {{ c.EVENT_NAME }}.  If you have any questions,
+              please contact <b>{{ c.PANELS_EMAIL }}</b>.
+            </p>
+            <div class="col-sm-9 col-sm-offset-3">
+              <label class="checkbox-label" style="font-weight: normal;">
+                <input type="checkbox" name="verify_tos" {% if verify_tos %}checked{% endif %} />
+                I have read and agree to the terms above.
+              </label>
             </div>
+          </div>
 
-            <div class="form-group">
-                <div class="col-sm-6 col-sm-offset-3">
-                    <button type="submit" class="btn btn-primary">Submit Application</button>
-                </div>
+          <div class="form-group">
+            <div class="col-sm-6 col-sm-offset-3">
+              <button type="submit" class="btn btn-primary">Submit Application</button>
             </div>
+          </div>
 
         </form>
-    {% endif %}
+      {% endif %}
+    </div>
   </div>
-</div>
 
 {% endblock %}

--- a/panels/templates/panel_applications/index.html
+++ b/panels/templates/panel_applications/index.html
@@ -9,34 +9,15 @@
     var showOrHidePOC = function () {
         setVisible('#point_of_contact', $.val('other_panelists'));
     };
-    var showOrHideOtherPanelists = function () {
-        var count = $.val('other_panelists'),
-            $template = $('#panelist_form_template > .panel'),
-            $ops = $('#panelists_container > .panel');
-        setVisible('#panelists_container', count);
-        if (count < $ops.size()) {
-            $ops.slice(count).remove();
-        } else {
-            for (var i = $ops.size() + 1; i <= count; i++) {
-                var suffix = '_' + i;
-                $opPanel = $template.clone();
-                $opPanel.find('h2').text($opPanel.find('h2').text() + i);
-                $opPanel.find('input').attr('name', function() { return $(this).attr('name') + suffix } );
-                $opPanel.find('textarea').attr('name', function() { return $(this).attr('name') + suffix } );
-                $opPanel.appendTo('#panelists_container');
-            }
-        }
-    };
 
     $(function () {
         $('<br/>').insertBefore('nobr');
         showOrHidePOC();
-        showOrHideOtherPanelists();
         $.field('other_panelists').on('change', showOrHidePOC);
-        $.field('other_panelists').on('change', showOrHideOtherPanelists);
     });
 </script>
 
+{# This needs to be placed outside the <form> tag or we get validation errors #}
 <div id="panelist_form_template" style="display: none;">
   <div class="panel panel-default">
     <div class="panel-body">
@@ -161,29 +142,7 @@
             </div>
 
             <h3>Other Panelists</h3>
-            <div class="form-group">
-                <div class="col-sm-6 col-sm-offset-3">
-                    <select name="other_panelists">
-                        {{ int_options(0, 9, ops_count) }}
-                    </select>
-                    How many other panelists will be on this panel?
-                </div>
-            </div>
-
-            <div id="panelists_container">
-              {% for op in other_panelists %}
-                <div class="panel panel-default">
-                  <div class="panel-body">
-                    <h2>Other Panelist #{{ loop.index }}</h2>
-                    {{ panel_macros.panelist_form(
-                        op,
-                        suffix='_' + loop.index0|string,
-                        require_cellphone=False,
-                        require_communication_pref=False) }}
-                  </div>
-                </div>
-              {% endfor %}
-            </div>
+            {% include "other_panelists_form.html" %}
 
             <div id="point_of_contact" class="form-group" style="display:none">
                 <p class="col-sm-9 col-sm-offset-3">
@@ -202,7 +161,7 @@
                 </div>
             </div>
 
-            <h3>Panelist Terms of Accomodation</h3>
+            <h3>Panelist Terms of Accommodation</h3>
             <div class="form-group">
                 <p class="col-sm-9 col-sm-offset-3">
                     "Panelists" at {{ c.EVENT_NAME }} receive free admission and


### PR DESCRIPTION
This is the second major refactor required for https://github.com/magfest/ubersystem/issues/2489 -- it adds a panel application form tailored for guests and other pre-approved and pre-existing panelists. It also factors out some panel processing functions to avoid code duplication.