### PR TITLE
Customize panel application for guests

### DIFF
--- a/alembic/versions/2f5f9d87b056_add_available_column.py
+++ b/alembic/versions/2f5f9d87b056_add_available_column.py
@@ -1,0 +1,63 @@
+"""Add available column
+
+Revision ID: 2f5f9d87b056
+Revises: 416eb615ff1a
+Create Date: 2017-09-27 14:05:52.746446
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '2f5f9d87b056'
+down_revision = '416eb615ff1a'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    if is_sqlite:
+        with op.batch_alter_table('panel_application', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.add_column(sa.Column('available', sa.Unicode(), server_default='', nullable=False))
+    else:
+        op.add_column('panel_application', sa.Column('available', sa.Unicode(), server_default='', nullable=False))
+
+
+def downgrade():
+    op.drop_column('panel_application', 'available')

--- a/panels/model_checks.py
+++ b/panels/model_checks.py
@@ -21,8 +21,7 @@ def overlapping_events(event, other_event_id=None):
 PanelApplication.required = [
     ('name', 'Panel Name'),
     ('description', 'Panel Description'),
-    ('length', 'Panel Length'),
-    ('unavailable', 'Your unavailability'),
+    ('length', 'Panel Length')
 ]
 PanelApplicant.required = [
     ('first_name', 'First Name'),
@@ -45,36 +44,48 @@ def pa_phone(pa):
 
 
 @validation.PanelApplication
-def pa_other(pa):
-    if pa.presentation == c.OTHER and not pa.other_presentation:
+def unavailability(app):
+    if not app.unavailable and not app.poc_id:
+        return 'Your unavailability is required.'
+
+
+@validation.PanelApplication
+def availability(app):
+    if not app.available and app.poc_id:
+        return 'Please list the times you are available to hold this panel!'
+
+
+@validation.PanelApplication
+def panel_other(app):
+    if app.presentation == c.OTHER and not app.other_presentation:
         return 'Since you selected "Other" for your type of panel, please describe it'
 
 
 @validation.PanelApplication
-def pa_deadline(pa):
-    if localized_now() > c.PANEL_APP_DEADLINE and not c.HAS_PANEL_APPS_ACCESS:
+def app_deadline(app):
+    if localized_now() > c.PANEL_APP_DEADLINE and not c.HAS_PANEL_APPS_ACCESS and not app.poc_id:
         return 'We are now past the deadline and are no longer accepting panel applications'
 
 
 @validation.PanelApplication
-def specify_other_time(pa):
-    if pa.length == c.OTHER and not pa.length_text:
+def specify_other_time(app):
+    if app.length == c.OTHER and not app.length_text:
         return 'Please specify how long your panel will be.'
 
 
 @validation.PanelApplication
-def specify_nonstandard_time(pa):
-    if pa.length != c.SIXTY_MIN and not pa.length_reason:
+def specify_nonstandard_time(app):
+    if app.length != c.SIXTY_MIN and not app.length_reason and not app.poc_id:
         return 'Please explain why your panel needs to be longer than sixty minutes.'
 
 
 @validation.PanelApplication
-def specify_table_needs(pa):
-    if pa.need_tables and not pa.tables_desc:
+def specify_table_needs(app):
+    if app.need_tables and not app.tables_desc:
         return 'Please describe how you need tables set up for your panel.'
 
 
 @validation.PanelApplication
-def specify_cost_details(pa):
-    if pa.has_cost and not pa.cost_desc:
+def specify_cost_details(app):
+    if app.has_cost and not app.cost_desc:
         return 'Please describe the materials you will provide and how much you will charge attendees for them.'

--- a/panels/models.py
+++ b/panels/models.py
@@ -112,6 +112,7 @@ class PanelApplication(MagModel):
     length_reason = Column(UnicodeText)
     description = Column(UnicodeText)
     unavailable = Column(UnicodeText)
+    available = Column(UnicodeText)
     affiliations = Column(UnicodeText)
     past_attendance = Column(UnicodeText)
 

--- a/panels/templates/panel_app_form.html
+++ b/panels/templates/panel_app_form.html
@@ -5,15 +5,19 @@
         $.field('other_presentation').prop('required', isOtherPresentation);
     };
     var showOrHideOtherLength = function() {
-        var isOther = $.val('length') === {{ c.OTHER }},
-            isNotAnHour = $.val('length') != {{ c.SIXTY_MIN }};
+        var isOther = $.val('length') === {{ c.OTHER }};
         setVisible($('#other-length'), isOther);
         $.field('length_text').prop('required', isOther);
         if (!isOther) {
             $.field('length_text').val('');
         }
+    };
+    var showOrHideLengthReason = function () {
+        {% if not poc_id %}
+        var isNotAnHour = $.val('length') != {{ c.SIXTY_MIN }};
         setVisible($.field('length_reason').parents('.form-group'), isNotAnHour);
         $.field('length_reason').prop('required', isNotAnHour);
+        {% endif %}
     };
     var showOrHideModHelp = function() {
         setVisible($('#mod_help'), $.val('presentation') === {{ c.GROUP_DISCUSSION }})
@@ -22,10 +26,12 @@
     $(function () {
         showOrHideOtherPresentation();
         showOrHideOtherLength();
+        showOrHideLengthReason();
         showOrHideModHelp();
         $.field('presentation').on('change', showOrHideOtherPresentation);
         $.field('presentation').on('change', showOrHideModHelp);
         $.field('length').on('change', showOrHideOtherLength);
+        $.field('length').on('change', showOrHideLengthReason);
     });
 </script>
 <div class="form-group">
@@ -77,7 +83,7 @@
         An hour is typical, including time for Q&A.
     </p>
 </div>
-<div class="form-group">
+<div class="form-group"{% if poc_id %} style="display:none"{% endif %}>
     <label class="col-sm-3 control-label">Why do you need the extra time?</label>
     <div class="col-sm-6">
         <textarea class="form-control" name="length_reason" rows="4">{{ app.length_reason }}</textarea>

--- a/panels/templates/panel_applications/guest.html
+++ b/panels/templates/panel_applications/guest.html
@@ -12,6 +12,8 @@
     {% if c.APP_LIMIT and attendee.panel_applications|length >= c.APP_LIMIT %}
       You have already submitted the maximum number of panels ({{ c.APP_LIMIT }}). Please contact your liaison if
       you need to change a panel or submit more ideas.
+
+      <br/><br/><a href="{{ return_to }}" class="btn btn-primary">Go Back</a>
     {% else %}
       {% if c.APP_LIMIT %}
         You may submit up to {{ c.APP_LIMIT }} panel ideas.
@@ -22,29 +24,22 @@
       <form method="post" action="guest" class="form-horizontal" role="form">
 
       <input type="hidden" name="poc_id" value="{{ poc_id }}" />
+      <input type="hidden" name="return_to" value="{{ return_to }}" />
 
       <h3>Panel Information</h3>
       {% include "panel_app_form.html" %}
 
       <h3>Additional Information</h3>
       <div class="form-group">
-        <label class="col-sm-3 control-label">When are you unavailable?</label>
+        <label class="col-sm-3 control-label">When are your preferred panel times?</label>
         <div class="col-sm-6">
-          <textarea class="form-control" name="unavailable" rows="4" required="required">{{ app.unavailable }}</textarea>
+          <textarea class="form-control" name="available" rows="4" required="required">{{ app.available }}</textarea>
         </div>
         <div class="clearfix"></div>
         <p class="help-block col-sm-9 col-sm-offset-3">
-          Please list all times during the event when you will be UNAVAILABLE to hold your panel.
-          If we book you into a time slot, that is very difficult to change, so please be thorough.
+          Please let us know the time slot you would prefer for this panel. Panel times can’t be guaranteed, but we’ll
+          do our best to accommodate preferences.
         </p>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-9 col-sm-offset-3">
-          <label class="checkbox-label" style="font-weight: normal;">
-            <input type="checkbox" name="verify_unavailable" {% if verify_unavailable %}checked{% endif %} />
-            I verify I am available at any time during the event EXCEPT for the times listed above.
-          </label>
-        </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">What else might we need to know?</label>
@@ -63,6 +58,9 @@
       <div class="form-group">
         <div class="col-sm-6 col-sm-offset-3">
           <button type="submit" class="btn btn-primary">Submit Panel Idea</button>
+          {% if not c.APP_LIMIT or attendee.panel_applications|length < c.APP_LIMIT %}
+            <button type="submit" name="ignore_return_to" value="1" class="btn btn-success">Submit and Add Another Panel</button>
+          {% endif %}
         </div>
       </div>
       </form>


### PR DESCRIPTION
Add an 'available' column so we can ask guests their for availability, not unavailability. Also removes the sixty minute checks, and allows a "return_to" parameter so guests can go back to their checklist when they're done.