### PR TITLE
Adds migration stub to merge erroneous alembic branches

### DIFF
--- a/alembic/versions/b4a97b074ef2_stub_to_merge_panels_branches.py
+++ b/alembic/versions/b4a97b074ef2_stub_to_merge_panels_branches.py
@@ -1,0 +1,22 @@
+"""Stub to merge panels branches and rewrite the branch history
+
+Revision ID: b4a97b074ef2
+Revises: 2f5f9d87b056, 3733faf640e9, a3d71270256c
+Create Date: 2017-10-18 20:32:15.873425
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'b4a97b074ef2'
+down_revision = ('2f5f9d87b056', '3733faf640e9', 'a3d71270256c')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
# Current panels migration branches
I just noticed that each of our `panels` migration scripts are branched from the same version, so we now have three different `heads` in the panels plugin. The branches in the `panels` plugin currently look like this:
```
# current panels branches

                +-> 2f5f9d87b056 (head)
               /                 
416eb615ff1a -+---> 3733faf640e9 (head)
               \                 
                +-> a3d71270256c (head)
```

# Panels branches after merge
The migration in this pull request is an [alembic branch merge](http://alembic.zzzcomputing.com/en/latest/branches.html#merging-branches). The migration itself is empty, but it will unify the three `panels` branches and give `panels` a single `head`. After the migration, the branches in the `panels` plugin will look like this:
```
# panels branches after this migration

                +-> 2f5f9d87b056 -+
               /                   \
416eb615ff1a -+---> 3733faf640e9 ---+-> b4a97b074ef2 (head)
               \                   /
                +-> a3d71270256c -+
```

# Panels branches after rewriting migration history
Only the list of current `heads` are stored by Alembic in the database. Once we have deployed this migration to all of our servers, we can freely rewrite our migration history to remove the branches and make it linear. We aren't able to rewrite our migration history right now, because each of the `panels` `heads` are referenced by alembic in the database.

Rewriting the migration history will require an additional pull request. And we can't merge that additional pull request in GitHub until *AFTER* the alembic merge migration has been deployed to all of our servers.

Rewriting the migration history is not strictly necessary. It's additional work, but it will clean up our history, and more closely reflect reality:
```
# panels branches after rewriting migration history

416eb615ff1a -> 3733faf640e9 -> a3d71270256c -> 2f5f9d87b056 -> b4a97b074ef2 (head)
```