### PR TITLE
Allow admins to associate events with panel applications more seamlessly

### DIFF
--- a/panels/models.py
+++ b/panels/models.py
@@ -99,7 +99,10 @@ class AssignedPanelist(MagModel):
     event_id    = Column(UUID, ForeignKey('event.id', ondelete='cascade'))
 
     def __repr__(self):
-        return '<{self.attendee.full_name} panelisting {self.event.name}>'.format(self=self)
+        if self.attendee:
+            return '<{self.attendee.full_name} panelisting {self.event.name}>'.format(self=self)
+        else:
+            return super(AssignedPanelist, self).__repr__()
 
 
 class PanelApplication(MagModel):

--- a/panels/site_sections/panel_applications.py
+++ b/panels/site_sections/panel_applications.py
@@ -88,6 +88,8 @@ class Root:
         app = session.panel_application(params, checkgroups=PanelApplication.all_checkgroups, restricted=True, ignore_csrf=True)
         app.poc_id = poc_id
         attendee = session.attendee(id=poc_id)
+        if attendee.badge_type != c.GUEST_BADGE:
+            add_opt(attendee.ribbon_ints, c.PANELIST_RIBBON)
         panelist = PanelApplicant(
             app_id=app.id,
             attendee_id=attendee.id,

--- a/panels/site_sections/schedule.py
+++ b/panels/site_sections/schedule.py
@@ -186,7 +186,6 @@ class Root:
                         if pa.attendee_id:
                             assigned_panelist = AssignedPanelist(attendee_id=pa.attendee.id, event_id=event.id)
                             session.add(assigned_panelist)
-                    #event.assigned_panelists = [pa.attendee for pa in add_panel.panel_applicants]
 
             message = check(event)
             if not message:

--- a/panels/templates/schedule/form.html
+++ b/panels/templates/schedule/form.html
@@ -31,6 +31,15 @@
             addPanelist(id);
         });
     });
+    {% if event.is_new %}
+        var showOrHidePanelDetails = function() {
+            setVisible(".panel-details", !($.val('panel_id')))
+        };
+        $(function() {
+            showOrHidePanelDetails();
+            $.field('panel_id').on('change', showOrHidePanelDetails);
+        });
+    {% endif %}
 </script>
 
 <form method="post" action="form">
@@ -63,21 +72,32 @@
     </td>
 </tr>
 <tr>
-    <td><b>Event Name:</b></td>
-    <td>
-        <input class="focus" type="text" name="name" value="{{ event.name }}" />
-        {% for app in event.applications %}
-            <br/> (<a href="../panel_app_management/app?id={{ app.id }}">view application</a>)
-        {% endfor %}
-    </td>
+  <td>Panel Application:</td>
+  <td>
+    <select name="panel_id" id="panel_id">
+      <option selected="true" value="">Associate a panel application with this event</option>
+      {% for panel in approved_panel_apps %}
+        <option value="{{ panel.id }}">{{ panel.name }} ({{ panel.length_text if panel.length_text else panel.length_label }})</option>
+      {% endfor %}
+    </select>
+    {% for app in event.applications %}
+      <br/> (<a href="../panel_app_management/app?id={{ app.id }}">view application</a>)
+    {% endfor %}
+  </td>
 </tr>
-<tr>
+<tr class="panel-details">
     <td valign="top">Panelists</td>
     <td>
         <a id="add" href="#" onClick="addPanelist(); return false">Add a Panelist</a>
     </td>
 </tr>
-<tr>
+<tr class="panel-details">
+    <td><b>Event Name:</b></td>
+    <td>
+        <input class="focus" type="text" name="name" value="{{ event.name }}" />
+    </td>
+</tr>
+<tr class="panel-details">
     <td valign="top">Description:</td>
     <td> <textarea rows="6" cols="40" name="description">{{ event.description }}</textarea> </td>
 </tr>


### PR DESCRIPTION
Right now, admins must create an event, then go to a totally different page to associate a panel application with that event. This seems silly, because it forces the admin to work in two separate places and to manually copy over panel names and descriptions. Now admins can associate events with panel applications while editing an event; additionally, if they associate a new event with a panel app, they can skip entering in name/desc. Any panelists associated with the panel app also get added to the event.