### PR TITLE
Allows attraction checkin page to be used by attendee with the same permissions as a reg station

### DIFF
--- a/panels/models/attraction.py
+++ b/panels/models/attraction.py
@@ -333,6 +333,10 @@ class AttractionEvent(MagModel):
         return self.end_time.astimezone(c.EVENT_TIMEZONE)
 
     @property
+    def start_day_local(self):
+        return self.start_time_local.strftime('%A')
+
+    @property
     def start_time_local(self):
         return self.start_time.astimezone(c.EVENT_TIMEZONE)
 

--- a/panels/site_sections/attractions_admin.py
+++ b/panels/site_sections/attractions_admin.py
@@ -331,7 +331,7 @@ class Root:
         if message:
             return {'error': message}
 
-    @only_renderable(c.STUFF, c.PEOPLE, c.REG_AT_CON)
+    @renderable_override(c.STUFF, c.PEOPLE, c.REG_AT_CON)
     def checkin(self, session, message='', **params):
         id = params.get('id')
         if not id:
@@ -349,7 +349,7 @@ class Root:
 
         return {'attraction': attraction, 'message': message}
 
-    @only_renderable(c.STUFF, c.PEOPLE, c.REG_AT_CON)
+    @renderable_override(c.STUFF, c.PEOPLE, c.REG_AT_CON)
     @ajax
     def get_signups(self, session, badge_num, attraction_id=None):
         if cherrypy.request.method == 'POST':
@@ -388,7 +388,7 @@ class Root:
                 }
             }
 
-    @only_renderable(c.STUFF, c.PEOPLE, c.REG_AT_CON)
+    @renderable_override(c.STUFF, c.PEOPLE, c.REG_AT_CON)
     @ajax
     def checkin_signup(self, session, id):
         message = ''
@@ -403,7 +403,7 @@ class Root:
         if message:
             return {'error': message}
 
-    @only_renderable(c.STUFF, c.PEOPLE, c.REG_AT_CON)
+    @renderable_override(c.STUFF, c.PEOPLE, c.REG_AT_CON)
     @ajax
     def undo_checkin_signup(self, session, id):
         if cherrypy.request.method == 'POST':

--- a/panels/templates/attractions_admin/form.html
+++ b/panels/templates/attractions_admin/form.html
@@ -560,7 +560,7 @@
       <span class="glyphicon glyphicon-cog"></span>
     </button>
   {%- endif %}
-  <a href="checkin?id={{ attraction.id }}" class="btn btn-xs btn-primary">
+  <a href="checkin?id={{ attraction.slug }}" class="btn btn-xs btn-primary">
     <span class="glyphicon glyphicon-check"></span>
     Check In Attendees
   </a>


### PR DESCRIPTION
I realized that attractions might have attendees working the checkin booth that might not have full admin privileges, like we do at reg. This allows someone with more limited access to still use the checkin page.

Also makes the URL a little nicer:
https://localhost:4443/uber/attractions_admin/checkin?id=escape-room
instead of:
https://localhost:4443/uber/attractions_admin/checkin?id=ff5828b7-1e48-4fd4-91ef-a38e4c95a1e1