### PR TITLE
Attendees can sign up for attractions without badge numbers

### DIFF
--- a/panels/site_sections/attractions.py
+++ b/panels/site_sections/attractions.py
@@ -20,12 +20,10 @@ def _attendee_for_badge_num(session, badge_num, options=None):
 
 
 def _attendee_for_info(session, first_name, last_name, email, zip_code):
-    return session.query(Attendee).filter(
-        func.lower(Attendee.first_name) == first_name.lower(),
-        func.lower(Attendee.last_name) == last_name.lower(),
-        Attendee.normalized_email == Attendee.normalize_email(email),
-        Attendee.zip_code == zip_code
-    ).first()
+    try:
+        return session.lookup_attendee(first_name, last_name, email, zip_code)
+    except:
+        return None
 
 
 def _model_for_id(session, model, id, options=None, filters=[]):

--- a/panels/site_sections/attractions.py
+++ b/panels/site_sections/attractions.py
@@ -23,7 +23,7 @@ def _attendee_for_info(session, first_name, last_name, email, zip_code):
     return session.query(Attendee).filter(
         func.lower(Attendee.first_name) == first_name.lower(),
         func.lower(Attendee.last_name) == last_name.lower(),
-        func.lower(Attendee.email) == email.lower(),
+        Attendee.normalized_email == Attendee.normalize_email(email),
         Attendee.zip_code == zip_code
     ).first()
 

--- a/panels/site_sections/attractions.py
+++ b/panels/site_sections/attractions.py
@@ -19,6 +19,15 @@ def _attendee_for_badge_num(session, badge_num, options=None):
     return query.first()
 
 
+def _attendee_for_info(session, first_name, last_name, email, zip_code):
+    return session.query(Attendee).filter(
+        func.lower(Attendee.first_name) == first_name.lower(),
+        func.lower(Attendee.last_name) == last_name.lower(),
+        func.lower(Attendee.email) == email.lower(),
+        Attendee.zip_code == zip_code
+    ).first()
+
+
 def _model_for_id(session, model, id, options=None, filters=[]):
     if not id:
         return None
@@ -114,10 +123,19 @@ class Root:
             'badge_num': attendee.badge_num}
 
     @ajax
-    def signup_for_event(self, session, badge_num, id, **params):
-        attendee = _attendee_for_badge_num(session, badge_num)
-        if not attendee:
-            return {'error': 'Unrecognized badge number: {}'.format(badge_num)}
+    def signup_for_event(self, session, id, badge_num='', first_name='',
+                               last_name='', email='', zip_code='', **params):
+        if badge_num:
+            attendee = _attendee_for_badge_num(session, badge_num)
+            if not attendee:
+                return {
+                    'error': 'Unrecognized badge number: {}'.format(badge_num)
+                }
+        else:
+            attendee = _attendee_for_info(session, first_name, last_name,
+                                                   email, zip_code)
+            if not attendee:
+                return {'error': 'No attendee is registered with that info'}
 
         event = _model_for_id(session, AttractionEvent, id)
         if not event:

--- a/panels/templates/attractions/attractions_common.html
+++ b/panels/templates/attractions/attractions_common.html
@@ -20,6 +20,10 @@
     .visible-xs-inline { display: none !important; }
     .visible-xs-inline-block { display: none !important; }
     .hidden-xs { display: initial !important; }
+    .attendee-info-row input {
+      width: 15em;
+      margin-left: 2em;
+    }
   }
 
   @media(max-width: 499px) {

--- a/panels/templates/attractions/attractions_common.html
+++ b/panels/templates/attractions/attractions_common.html
@@ -212,6 +212,10 @@
     display: inline-block;
   }
 
+  .hidden-soldout.hidden-modal-form {
+    display: none;
+  }
+
   .btn-back {
   }
 

--- a/panels/templates/attractions/events.html
+++ b/panels/templates/attractions/events.html
@@ -75,7 +75,7 @@
   $(function() {
     var $modals = $('.modal'),
         $signupModal = $('#signup_modal'),
-        $earlySignupModal = $('#early_signup_modal'),
+        $altSignupModal = $('#alt_signup_modal'),
         $doneModal = $('#done_modal'),
         $btnShowSoldout = $('#btn_show_soldout');
 
@@ -136,7 +136,7 @@
 
     $signupModal.find('.modal-footer .btn.modal-form-switch').on('click', function (event) {
       $signupModal.modal('hide');
-      $earlySignupModal.modal('show');
+      $altSignupModal.modal('show');
     });
 
     $signupModal.find('.confirm-row .btn-success').on('click', function (event) {
@@ -176,7 +176,7 @@
       });
     });
 
-    $earlySignupModal.find('.modal-footer .btn-success').on('click', function () {
+    $altSignupModal.find('.modal-footer .btn-success').on('click', function () {
       event.preventDefault();
       var eventId = $signupModal.data('eventId');
       var params = {
@@ -187,8 +187,9 @@
       };
       signupForEvent(eventId, params, function (response) {
         if (response) {
-          $earlySignupModal.modal('hide');
-          toastr.info('Signup succeeded.');
+          $altSignupModal.modal('hide');
+          $doneModal.data('hideForm', true);
+          $doneModal.modal('show');
         }
       });
     });
@@ -201,8 +202,19 @@
       focusBadgeNum($(this));
     });
 
-    $earlySignupModal.on('shown.bs.modal', function () {
-      $earlySignupModal.find('input[name=first_name]').focus();
+    $doneModal.on('shown.bs.modal', function () {
+        if ($doneModal.data('hideForm')) {
+            $doneModal.find('.hidden-soldout').addClass('hidden-modal-form');
+        } else {
+            $doneModal.find('.hidden-soldout').removeClass('hidden-modal-form');
+        }
+    });
+    $doneModal.on('hide.bs.modal', function () {
+        $doneModal.removeData('hideForm');
+    });
+
+    $altSignupModal.on('shown.bs.modal', function () {
+      $altSignupModal.find('input[name=first_name]').focus();
     });
   });
 </script>
@@ -243,8 +255,8 @@
   </div>
 </div>
 
-<div id="early_signup_modal" class="modal fade" tabindex="-1" role="dialog" style="display: none"
-    aria-labelledby="early_signup_modal_title">
+<div id="alt_signup_modal" class="modal fade" tabindex="-1" role="dialog" style="display: none"
+    aria-labelledby="alt_signup_modal_title">
   <div class="modal-dialog modal-md" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/panels/templates/attractions/events.html
+++ b/panels/templates/attractions/events.html
@@ -75,6 +75,7 @@
   $(function() {
     var $modals = $('.modal'),
         $signupModal = $('#signup_modal'),
+        $earlySignupModal = $('#early_signup_modal'),
         $doneModal = $('#done_modal'),
         $btnShowSoldout = $('#btn_show_soldout');
 
@@ -107,15 +108,14 @@
       $signupModal.modal('show');
     });
 
-    var signupForEvent = function(eventId, badgeNum, callback) {
+    var signupForEvent = function(eventId, extraParams, callback) {
       $.ajax({
         method: 'POST',
         url: 'signup_for_event',
-        data: {
-          badge_num: badgeNum,
+        data: $.extend({
           id: eventId,
           csrf_token: csrf_token
-        },
+        }, extraParams),
         success: function(response, status) {
           if (response && response['event_id']) {
             $modals.toggleClass('soldout', response['is_sold_out']);
@@ -134,13 +134,18 @@
       });
     };
 
+    $signupModal.find('.modal-footer .btn.modal-form-switch').on('click', function (event) {
+      $signupModal.modal('hide');
+      $earlySignupModal.modal('show');
+    });
+
     $signupModal.find('.confirm-row .btn-success').on('click', function (event) {
       event.preventDefault();
       var eventId = $signupModal.data('eventId'),
           $badgeNum = $signupModal.find('input[name=badge_num]'),
           badgeNum = $badgeNum.val();
 
-      signupForEvent(eventId, badgeNum, function(response) {
+      signupForEvent(eventId, {badge_num: badgeNum}, function(response) {
         if (response) {
           updateGreeting(response['first_name'], response['badge_num'], $doneModal.find('.modal-title'));
           $doneModal.data('badgeNum', badgeNum);
@@ -155,7 +160,7 @@
       var eventId = $doneModal.data('eventId'),
           $badgeNum = $doneModal.find('input[name=badge_num]');
 
-      signupForEvent(eventId, $badgeNum.val(), function(response) {
+      signupForEvent(eventId, {badge_num: $badgeNum.val()}, function(response) {
         if (response) {
           var $attendee = $doneModal.find('.confirm-row .attendee'),
               $eventLabel = $('#' + eventId + ' .event-label'),
@@ -171,12 +176,33 @@
       });
     });
 
+    $earlySignupModal.find('.modal-footer .btn-success').on('click', function () {
+      event.preventDefault();
+      var eventId = $signupModal.data('eventId');
+      var params = {
+        first_name: $.val('first_name'),
+        last_name: $.val('last_name'),
+        email: $.val('email'),
+        zip_code: $.val('zip_code')
+      };
+      signupForEvent(eventId, params, function (response) {
+        if (response) {
+          $earlySignupModal.modal('hide');
+          toastr.info('Signup succeeded.');
+        }
+      });
+    });
+
     $modals.on('show.bs.modal', function (event) {
       resetBadgeNum($(this));
     });
 
     $modals.on('shown.bs.modal', function (event) {
       focusBadgeNum($(this));
+    });
+
+    $earlySignupModal.on('shown.bs.modal', function () {
+      $earlySignupModal.find('input[name=first_name]').focus();
     });
   });
 </script>
@@ -210,7 +236,70 @@
         {{ attractions_macros.badge_num_form('All we need is your badge number!') }}
       </div>
       <div class="modal-footer">
+        <button class="btn btn-default btn-lg btn-xl modal-form-switch">I don't have my badge yet</button>
         <button class="btn btn-default btn-lg btn-xl" data-dismiss="modal">Nevermind</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="early_signup_modal" class="modal fade" tabindex="-1" role="dialog" style="display: none"
+    aria-labelledby="early_signup_modal_title">
+  <div class="modal-dialog modal-md" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">
+          <span class="bling-icon"></span> <span class="signup-event-label"></span>
+        </h4>
+      </div>
+      <div class="modal-body">
+        <p>Enter your personal information to sign up.  You must already be registered to sign up for this event.</p>
+        <form class="form-horizontal badge-num-form" method="post" action="sign" role="form">
+          <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-8">
+              <div class="row">
+                <div class="attendee-info-row row">
+                  <input class="form-control input-lg info-field"
+                      type="text"
+                      name="first_name"
+                      placeholder="First Name"
+                      required="required" />
+                </div>
+                <div class="attendee-info-row row">
+                  <input class="form-control input-lg info-field"
+                      type="text"
+                      name="last_name"
+                      placeholder="Last Name"
+                      required="required" />
+                </div>
+                <div class="attendee-info-row row">
+                  <input class="form-control input-lg info-field"
+                      type="text"
+                      name="email"
+                      placeholder="Email Address"
+                      required="required" />
+                </div>
+                <div class="attendee-info-row row">
+                  <input class="form-control input-lg info-field"
+                      type="number"
+                      name="zip_code"
+                      placeholder="Zip Code"
+                      required="required" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-default btn-lg btn-xl" data-dismiss="modal">Nevermind</button>
+        <button class="btn btn-default btn-lg btn-xl btn-success">
+            <span class="glyphicon glyphicon-ok"></span> Sign up
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
As discussed on the code@magfest.org mailing list earlier this week, this allows people to sign up for attractions before the event starts by entering their name/email/zipcode.

We originally talked about making this configurable on a per-feature basis, but it looks like Rob already added the ability for admins to toggle whether or not their attraction is ready for signups, which I believe handles that use case.

I tried a few different ways to add this, and I eventually settled on adding a "I don't have my badge yet" button to the signup modal:
![newfooterbutton](https://user-images.githubusercontent.com/651592/34192423-f53b5c7e-e51b-11e7-8278-dcde125bd4b5.png)

which opens a different modal form:
![newform](https://user-images.githubusercontent.com/651592/34192428-f901c91a-e51b-11e7-8a03-503f0ed39b3a.png)

I spent some time trying to dynamically swap out the contents of the existing modal, but it was difficult to make the styling work due to the different sizes of the respective forms.  This approach works and doesn't involve any serious copy/paste.

I don't own a smartphone, but I tested this out in Google Chrome using their "Device Toolbar" in the Developer Tools.  The "I don't have my badge yet" button is a little big due to being wordy (happy to take suggestions for a less wordy name) but other than that everything looks okay to me.