### PR TITLE
Removes delete-orphan from attraction_event.notifications relationship

### DIFF
--- a/panels/models/attraction.py
+++ b/panels/models/attraction.py
@@ -770,6 +770,7 @@ class AttractionSignup(MagModel):
 
     notifications = relationship(
         'AttractionNotification',
+        cascade='all',
         backref=backref(
             'signup',
             cascade='save-update,merge',


### PR DESCRIPTION
Just realized that deleting an AttractionSignup will also delete any associated AttractionNotifications, which is probably _not_ what we want.