### PR TITLE
Prevents alternate attraction signups during AT_THE_CON.

### DIFF
--- a/panels/notifications.py
+++ b/panels/notifications.py
@@ -96,14 +96,17 @@ def send_attraction_notifications(session):
                               'unassigned attendee', exc_info=True)
                 continue
 
+            # The first time someone signs up for an attractions, they always
+            # receive the welcome email (even if they've chosen SMS or None
+            # for their notification prefs). If they've chosen to receive SMS
+            # notifications, they'll also get a text message.
             is_first_signup = not(attendee.attraction_notifications)
 
             if not is_first_signup and \
                     attendee.notification_pref == Attendee.NOTIFICATION_NONE:
                 continue
 
-            use_text = not is_first_signup \
-                and twilio_client \
+            use_text = twilio_client \
                 and attendee.cellphone \
                 and attendee.notification_pref == Attendee.NOTIFICATION_TEXT
 
@@ -136,7 +139,8 @@ def send_attraction_notifications(session):
                     body = TEXT_TPL.format(signup=signup, checkin=checkin)
                     subject = ''
                     sid = send_sms(to_, body, from_)
-                else:
+
+                if not use_text or is_first_signup:
                     type_ = Attendee.NOTIFICATION_EMAIL
                     type_str = 'EMAIL'
                     from_ = c.ATTRACTIONS_EMAIL

--- a/panels/site_sections/attractions.py
+++ b/panels/site_sections/attractions.py
@@ -151,7 +151,9 @@ class Root:
     @ajax
     def signup_for_event(self, session, id, badge_num='', first_name='',
                          last_name='', email='', zip_code='', **params):
-        if badge_num:
+
+        # Badge number during AT_THE_CON is a hard requirement for Autographs
+        if badge_num or c.AT_THE_CON:
             attendee = _attendee_for_badge_num(session, badge_num)
             if not attendee:
                 return {

--- a/panels/templates/attractions/events.html
+++ b/panels/templates/attractions/events.html
@@ -247,7 +247,10 @@
         {{ attractions_macros.badge_num_form('All we need is your badge number!') }}
       </div>
       <div class="modal-footer">
-        <button class="btn btn-default btn-lg btn-xl modal-form-switch">I don't have my badge</button>
+        {# Signups with a badge number during AT_THE_CON is a hard requirement for Autographs #}
+        {% if not c.AT_THE_CON %}
+          <button class="btn btn-default btn-lg btn-xl modal-form-switch">I don't have my badge</button>
+        {% endif %}
         <button class="btn btn-default btn-lg btn-xl" data-dismiss="modal">Nevermind</button>
       </div>
     </div>


### PR DESCRIPTION
Also, always sends the welcome email for initial attractions signups.