### PR TITLE
Make "Anytime during event" actually do what it says

### DIFF
--- a/panels/models/attraction.py
+++ b/panels/models/attraction.py
@@ -666,7 +666,7 @@ class AttractionEvent(MagModel):
     def checkin_time(self):
         advance_checkin = self.attraction.advance_checkin
         if advance_checkin < 0:
-            return self.start_time
+            return self.end_time
         else:
             return self.start_time - timedelta(seconds=advance_checkin)
 


### PR DESCRIPTION
We have a config option for attractions for when check-in is required. Even though we had two separate options for "Anytime during event" and "When the event starts," they were actually doing the same thing. This makes them do what they say on the tin.