### PR TITLE
Emergency attractions fix, differentiates an event's checkin_start_time from checkin_end_time

### DIFF
--- a/panels/models/attraction.py
+++ b/panels/models/attraction.py
@@ -663,16 +663,32 @@ class AttractionEvent(MagModel):
         return 'unknown start time'
 
     @property
-    def checkin_time(self):
+    def checkin_start_time(self):
         advance_checkin = self.attraction.advance_checkin
         if advance_checkin < 0:
-            return self.end_time
+            return self.start_time
         else:
             return self.start_time - timedelta(seconds=advance_checkin)
 
     @property
-    def checkin_time_label(self):
-        checkin = self.checkin_time_local
+    def checkin_end_time(self):
+        advance_checkin = self.attraction.advance_checkin
+        if advance_checkin < 0:
+            return self.end_time
+        else:
+            return self.start_time
+
+    @property
+    def checkin_start_time_label(self):
+        checkin = self.checkin_start_time_local
+        today = datetime.now(c.EVENT_TIMEZONE)
+        if checkin.date() == today.date():
+            return checkin.strftime('%-I:%M %p')
+        return checkin.strftime('%-I:%M %p %a')
+
+    @property
+    def checkin_end_time_label(self):
+        checkin = self.checkin_end_time_local
         today = datetime.now(c.EVENT_TIMEZONE)
         if checkin.date() == today.date():
             return checkin.strftime('%-I:%M %p')
@@ -680,7 +696,7 @@ class AttractionEvent(MagModel):
 
     @property
     def time_remaining_to_checkin(self):
-        return self.checkin_time - datetime.now(pytz.UTC)
+        return self.checkin_start_time - datetime.now(pytz.UTC)
 
     @property
     def time_remaining_to_checkin_label(self):
@@ -689,7 +705,7 @@ class AttractionEvent(MagModel):
 
     @property
     def is_checkin_over(self):
-        return self.checkin_time < datetime.now(pytz.UTC)
+        return self.checkin_end_time < datetime.now(pytz.UTC)
 
     @property
     def is_sold_out(self):

--- a/panels/models/attraction.py
+++ b/panels/models/attraction.py
@@ -681,16 +681,16 @@ class AttractionEvent(MagModel):
     @property
     def checkin_start_time_label(self):
         checkin = self.checkin_start_time_local
-        today = datetime.now(c.EVENT_TIMEZONE)
-        if checkin.date() == today.date():
+        today = datetime.now(c.EVENT_TIMEZONE).date()
+        if checkin.date() == today:
             return checkin.strftime('%-I:%M %p')
         return checkin.strftime('%-I:%M %p %a')
 
     @property
     def checkin_end_time_label(self):
         checkin = self.checkin_end_time_local
-        today = datetime.now(c.EVENT_TIMEZONE)
-        if checkin.date() == today.date():
+        today = datetime.now(c.EVENT_TIMEZONE).date()
+        if checkin.date() == today:
             return checkin.strftime('%-I:%M %p')
         return checkin.strftime('%-I:%M %p %a')
 

--- a/panels/notifications.py
+++ b/panels/notifications.py
@@ -118,7 +118,7 @@ def send_attraction_notifications(session):
             # for "when checkin starts".
             advance_notice = min(advance_notices)
             if advance_notice == -1 or advance_notice > 1800:
-                checkin = 'is at {}'.format(event.checkin_time_label)
+                checkin = 'is at {}'.format(event.checkin_start_time_label)
             else:
                 checkin = humanize_timedelta(
                     event.time_remaining_to_checkin,
@@ -152,7 +152,7 @@ def send_attraction_notifications(session):
                     else:
                         template = 'emails/attractions_notification.html'
                         subject = 'Checkin for {} is at {}'.format(
-                            event.name, event.checkin_time_label)
+                            event.name, event.checkin_start_time_label)
 
                     body = render(template, {
                         'signup': signup,

--- a/panels/site_sections/attractions.py
+++ b/panels/site_sections/attractions.py
@@ -133,7 +133,7 @@ class Root:
                 s.is_unchecked_in for s in attendee.attraction_signups),
             'signups': sorted(
                 attendee.attraction_signups,
-                key=lambda s: s.event.checkin_time)}
+                key=lambda s: s.event.checkin_start_time)}
 
     @ajax
     def verify_badge_num(self, session, badge_num, **params):

--- a/panels/templates/attractions/manage.html
+++ b/panels/templates/attractions/manage.html
@@ -523,7 +523,7 @@
                   </p>
                   {% if not signup.is_checked_in %}
                     <p class="checkin_time checkin_time">
-                      Checkin is at <b>{{ signup.event.checkin_time_label }}</b>
+                      Checkin is at <b>{{ signup.event.checkin_start_time_label }}</b>
                     </p>
                   {% else %}
                     <p class="checkin_time text-success">


### PR DESCRIPTION
The notifications we were sending to attendees listed the event's _end_ time as the checkin time.